### PR TITLE
Leveling input fixes

### DIFF
--- a/src/components/ValidatedTextField.tsx
+++ b/src/components/ValidatedTextField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TextFieldProps } from "@material-ui/core/TextField";
 import { TextField } from "@material-ui/core";
 
@@ -7,11 +7,19 @@ interface Props {
   onChange: (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => void;
+  revalidateOn?: unknown[];
 }
 
-const ValidatedTextField: React.FC<Props & TextFieldProps> = (props) => {
+const ValidatedTextField: React.FC<Props & TextFieldProps> = ({
+  validator,
+  onChange,
+  revalidateOn = [],
+  value: _value,
+  error: _error,
+  ...rest
+}) => {
   const [isValid, setIsValid] = useState(true);
-  const { validator, onChange, value, error, ...rest } = props;
+  const ref = useRef<HTMLInputElement>(null);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -24,6 +32,19 @@ const ValidatedTextField: React.FC<Props & TextFieldProps> = (props) => {
     [onChange, validator]
   );
 
-  return <TextField onChange={handleChange} error={!isValid} {...rest} />;
+  useEffect(() => {
+    if (ref.current) {
+      setIsValid(validator(ref.current.value));
+    }
+  }, [revalidateOn, validator]);
+
+  return (
+    <TextField
+      inputRef={ref}
+      onChange={handleChange}
+      error={!isValid}
+      {...rest}
+    />
+  );
 };
 export default ValidatedTextField;

--- a/src/pages/leveling.tsx
+++ b/src/pages/leveling.tsx
@@ -80,7 +80,7 @@ function levelingCost(
   targetElite: number,
   targetLevel: number
 ): LevelingCost {
-  const costsByElite = Array(targetElite - startingElite + 1)
+  const costsByElite = Array(Math.max(targetElite - startingElite + 1, 0))
     .fill(0)
     .map((_, i) => {
       const elite = startingElite + i;

--- a/src/pages/leveling.tsx
+++ b/src/pages/leveling.tsx
@@ -306,6 +306,7 @@ const Leveling: React.FC = () => {
                     onChange={(e) =>
                       setStartingLevel(parseInt(e.target.value, 10))
                     }
+                    revalidateOn={[startingElite]}
                     validator={(value) => {
                       const numericValue = parseInt(value, 10);
                       return (
@@ -393,6 +394,7 @@ const Leveling: React.FC = () => {
                     onChange={(e) =>
                       setTargetLevel(parseInt(e.target.value, 10))
                     }
+                    revalidateOn={[targetElite]}
                     validator={(value) => {
                       const numericValue = parseInt(value, 10);
                       return (

--- a/src/pages/leveling.tsx
+++ b/src/pages/leveling.tsx
@@ -308,6 +308,9 @@ const Leveling: React.FC = () => {
                     }
                     revalidateOn={[startingElite]}
                     validator={(value) => {
+                      if (!operator) {
+                        return true;
+                      }
                       const numericValue = parseInt(value, 10);
                       return (
                         !Number.isNaN(numericValue) &&
@@ -396,6 +399,9 @@ const Leveling: React.FC = () => {
                     }
                     revalidateOn={[targetElite]}
                     validator={(value) => {
+                      if (!operator) {
+                        return true;
+                      }
                       const numericValue = parseInt(value, 10);
                       return (
                         !Number.isNaN(numericValue) &&


### PR DESCRIPTION
This PR fixes two bugs reported by PeterYR:

1. Levels are not revalidated upon their corresponding elite changing. For example, if chooses Aak (a 6* operator) and enters Lv80 (an invalid value for Elite 0), they see that that level is invalid. But if they then change the elite to Elite 2, then the level still shows as invalid, even though Lv80 is valid for Elite 2.
2. Selecting Elite 2 as the starting elite and Elite 0 as the ending elite causes the page to crash (as it tries to initialize an array of `targetElite - startingElite + 1`, or `-1` in this case).