### PR TITLE
Add item sanity value to items.json data

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "js-combinatorics": "^1.4.5",
     "material-ui-popup-state": "^1.7.1",
     "netlify-identity-widget": "^1.9.1",
+    "puppeteer": "^10.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",

--- a/scripts/items.ts
+++ b/scripts/items.ts
@@ -175,6 +175,9 @@ const SANITY_VALUE_CELL_ID = "feRucRPwWGZo";
 const STAGE_INFO_CELL_ID = "znmVNbnNWIre";
 const stageRegex = /^Activity (?<stageName>[A-Z0-9-]+) \([^)]+\).*Efficiency 100\.000%/;
 const itemRegex = /^(?<itemName>[^:]+): (?<sanityValue>[0-9.]+) sanity value/;
+const stageNameToKey = Object.fromEntries(
+  Object.entries(cnStageTable).map(([key, value]) => [value.code, key])
+);
 
 async function fetchLuzarkLPSolverOutput(): Promise<{
   efficientStageNames: string[];
@@ -195,7 +198,7 @@ async function fetchLuzarkLPSolverOutput(): Promise<{
     (el) => el.innerText,
     stagesOutputElement
   );
-  const efficientStageNames = stagesOutputText
+  const efficientStageNames = (stagesOutputText
     .split("\n")
     .map((line) => {
       const result = line.match(stageRegex);
@@ -204,7 +207,9 @@ async function fetchLuzarkLPSolverOutput(): Promise<{
       }
       return null;
     })
-    .filter((item) => item != null) as string[];
+    .filter((item) => item != null) as string[]).map(
+    (stageName) => stageNameToKey[stageName]
+  );
 
   const sanityValuesOutputElement = await page.$(
     `#cell-${SANITY_VALUE_CELL_ID} .output pre`

--- a/scripts/items.ts
+++ b/scripts/items.ts
@@ -173,7 +173,7 @@ const LUZARK_LP_SOLVER_URL =
   "https://colab.research.google.com/drive/1lHwJDG7WCAr3KMlxY-HLyD8-yG3boazq";
 const SANITY_VALUE_CELL_ID = "feRucRPwWGZo";
 const STAGE_INFO_CELL_ID = "znmVNbnNWIre";
-const stageRegex = /^Activity (?<stageName>[A-Z0-9-]+) \([^)]+\)/;
+const stageRegex = /^Activity (?<stageName>[A-Z0-9-]+) \([^)]+\).*Efficiency 100\.000%/;
 const itemRegex = /^(?<itemName>[^:]+): (?<sanityValue>[0-9.]+) sanity value/;
 
 async function fetchLuzarkLPSolverOutput(): Promise<{

--- a/scripts/items.ts
+++ b/scripts/items.ts
@@ -176,7 +176,9 @@ const STAGE_INFO_CELL_ID = "znmVNbnNWIre";
 const stageRegex = /^Activity (?<stageName>[A-Z0-9-]+) \([^)]+\).*Efficiency 100\.000%/;
 const itemRegex = /^(?<itemName>[^:]+): (?<sanityValue>[0-9.]+) sanity value/;
 const stageNameToKey = Object.fromEntries(
-  Object.entries(cnStageTable).map(([key, value]) => [value.code, key])
+  Object.entries(cnStageTable)
+    .filter(([key]) => !key.endsWith("#f#")) // challenge mode stage suffix
+    .map(([key, value]) => [value.code, key])
 );
 
 async function fetchLuzarkLPSolverOutput(): Promise<{

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -1,5 +1,71 @@
 [
   {
+    "id": "2001",
+    "name": "Drill Battle Record",
+    "tier": 2,
+    "sortId": 70004,
+    "ingredients": [],
+    "yield": 1,
+    "stages": {
+      "leastSanity": {
+        "stageSanityCost": 6,
+        "stageName": "0-3",
+        "itemSanityCost": 1.35,
+        "dropRate": 4.43
+      }
+    },
+    "sanityValue": 0.607
+  },
+  {
+    "id": "2002",
+    "name": "Frontline Battle Record",
+    "tier": 3,
+    "sortId": 70003,
+    "ingredients": [],
+    "yield": 1,
+    "stages": {
+      "leastSanity": {
+        "stageSanityCost": 15,
+        "stageName": "3-5",
+        "itemSanityCost": 3,
+        "dropRate": 5
+      }
+    },
+    "sanityValue": 1.214
+  },
+  {
+    "id": "2003",
+    "name": "Tactical Battle Record",
+    "tier": 4,
+    "sortId": 70002,
+    "ingredients": [],
+    "yield": 1,
+    "stages": {
+      "leastSanity": {
+        "stageSanityCost": 21,
+        "stageName": "S4-9",
+        "itemSanityCost": 5.72,
+        "dropRate": 3.67
+      }
+    },
+    "sanityValue": 3.035
+  },
+  {
+    "id": "2004",
+    "name": "Strategic Battle Record",
+    "tier": 5,
+    "sortId": 70001,
+    "stages": {
+      "leastSanity": {
+        "stageSanityCost": 30,
+        "stageName": "LS-5",
+        "itemSanityCost": 10,
+        "dropRate": 3
+      }
+    },
+    "sanityValue": 6.07
+  },
+  {
     "id": "3211",
     "name": "Vanguard Chip",
     "tier": 3,
@@ -18,10 +84,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-C-1",
-        "itemSanityCost": 36.67,
+        "itemSanityCost": 36.11,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 14.291
   },
   {
     "id": "3212",
@@ -42,10 +109,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-C-2",
-        "itemSanityCost": 73.43,
+        "itemSanityCost": 73.23,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 28.583
   },
   {
     "id": "3213",
@@ -68,7 +136,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 58.177
   },
   {
     "id": "3221",
@@ -89,10 +158,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-D-1",
-        "itemSanityCost": 35.6,
+        "itemSanityCost": 35.85,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 19.981
   },
   {
     "id": "3222",
@@ -113,10 +183,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-D-2",
-        "itemSanityCost": 72.34,
+        "itemSanityCost": 71.87,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 39.961
   },
   {
     "id": "3223",
@@ -139,7 +210,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 80.934
   },
   {
     "id": "3231",
@@ -160,10 +232,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-A-1",
-        "itemSanityCost": 35.04,
+        "itemSanityCost": 34.89,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 19.981
   },
   {
     "id": "3232",
@@ -184,10 +257,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-A-2",
-        "itemSanityCost": 71.82,
+        "itemSanityCost": 72.08,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 39.961
   },
   {
     "id": "3233",
@@ -210,7 +284,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 80.934
   },
   {
     "id": "3241",
@@ -231,10 +306,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-B-1",
-        "itemSanityCost": 37.29,
+        "itemSanityCost": 37.21,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 19.981
   },
   {
     "id": "3242",
@@ -255,10 +331,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-B-2",
-        "itemSanityCost": 72.07,
+        "itemSanityCost": 71.9,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 39.961
   },
   {
     "id": "3243",
@@ -281,7 +358,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 80.934
   },
   {
     "id": "3251",
@@ -302,10 +380,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-B-1",
-        "itemSanityCost": 34.79,
+        "itemSanityCost": 34.86,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 14.291
   },
   {
     "id": "3252",
@@ -326,10 +405,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-B-2",
-        "itemSanityCost": 71.93,
+        "itemSanityCost": 72.1,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 28.583
   },
   {
     "id": "3253",
@@ -352,7 +432,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 58.177
   },
   {
     "id": "3261",
@@ -373,10 +454,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-A-1",
-        "itemSanityCost": 37.02,
+        "itemSanityCost": 37.18,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 14.291
   },
   {
     "id": "3262",
@@ -397,10 +479,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-A-2",
-        "itemSanityCost": 72.18,
+        "itemSanityCost": 71.92,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 28.583
   },
   {
     "id": "3263",
@@ -423,7 +506,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 58.177
   },
   {
     "id": "3271",
@@ -444,10 +528,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-C-1",
-        "itemSanityCost": 35.35,
+        "itemSanityCost": 35.89,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 19.981
   },
   {
     "id": "3272",
@@ -468,10 +553,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-C-2",
-        "itemSanityCost": 70.62,
+        "itemSanityCost": 70.81,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 39.961
   },
   {
     "id": "3273",
@@ -494,7 +580,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 80.934
   },
   {
     "id": "3281",
@@ -515,10 +602,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "PR-D-1",
-        "itemSanityCost": 36.41,
+        "itemSanityCost": 36.15,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 14.291
   },
   {
     "id": "3282",
@@ -539,10 +627,11 @@
       "leastSanity": {
         "stageSanityCost": 36,
         "stageName": "PR-D-2",
-        "itemSanityCost": 71.66,
+        "itemSanityCost": 72.13,
         "dropRate": 0.5
       }
-    }
+    },
+    "sanityValue": 28.583
   },
   {
     "id": "3283",
@@ -565,7 +654,8 @@
         "sortId": 400001
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 58.177
   },
   {
     "id": "3301",
@@ -579,7 +669,8 @@
         "itemSanityCost": 3,
         "dropRate": 5
       }
-    }
+    },
+    "sanityValue": 1.544
   },
   {
     "id": "3302",
@@ -602,14 +693,9 @@
         "stageName": "CA-3",
         "itemSanityCost": 6.67,
         "dropRate": 3
-      },
-      "mostEfficient": {
-        "stageSanityCost": 30,
-        "stageName": "CA-5",
-        "itemSanityCost": 19.96,
-        "dropRate": 1.5
       }
-    }
+    },
+    "sanityValue": 3.958
   },
   {
     "id": "3303",
@@ -627,19 +713,21 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 30,
         "stageName": "CA-5",
         "itemSanityCost": 15,
         "dropRate": 2
       }
-    }
+    },
+    "sanityValue": 10.148
   },
   {
     "id": "4001",
     "name": "LMD",
     "tier": 4,
-    "sortId": 10004
+    "sortId": 10004,
+    "sanityValue": 0.004
   },
   {
     "id": "30011",
@@ -653,7 +741,8 @@
         "itemSanityCost": 3.24,
         "dropRate": 3.7
       }
-    }
+    },
+    "sanityValue": 1.104
   },
   {
     "id": "30012",
@@ -678,13 +767,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 6,
         "stageName": "1-7",
         "itemSanityCost": 4.82,
         "dropRate": 1.24
       }
-    }
+    },
+    "sanityValue": 3.366
   },
   {
     "id": "30013",
@@ -712,10 +802,11 @@
       "leastSanity": {
         "stageSanityCost": 12,
         "stageName": "2-4",
-        "itemSanityCost": 28.33,
+        "itemSanityCost": 28.38,
         "dropRate": 0.42
       }
-    }
+    },
+    "sanityValue": 16.586
   },
   {
     "id": "30014",
@@ -743,10 +834,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "R8-3",
-        "itemSanityCost": 315.33,
+        "itemSanityCost": 303.48,
         "dropRate": 0.06
       }
-    }
+    },
+    "sanityValue": 62.852
   },
   {
     "id": "30021",
@@ -757,10 +849,11 @@
       "leastSanity": {
         "stageSanityCost": 12,
         "stageName": "S2-6",
-        "itemSanityCost": 4.91,
+        "itemSanityCost": 4.92,
         "dropRate": 2.44
       }
-    }
+    },
+    "sanityValue": 1.867
   },
   {
     "id": "30022",
@@ -788,10 +881,11 @@
       "leastSanity": {
         "stageSanityCost": 15,
         "stageName": "S3-1",
-        "itemSanityCost": 9.91,
+        "itemSanityCost": 9.9,
         "dropRate": 1.51
       }
-    }
+    },
+    "sanityValue": 5.657
   },
   {
     "id": "30023",
@@ -819,16 +913,11 @@
       "leastSanity": {
         "stageSanityCost": 12,
         "stageName": "2-5",
-        "itemSanityCost": 32.67,
+        "itemSanityCost": 32.65,
         "dropRate": 0.37
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "4-2",
-        "itemSanityCost": 46.05,
-        "dropRate": 0.39
       }
-    }
+    },
+    "sanityValue": 22.383
   },
   {
     "id": "30024",
@@ -870,16 +959,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "5-2",
-        "itemSanityCost": 448.11,
-        "dropRate": 0.04
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "4-2",
-        "itemSanityCost": 449.34,
+        "itemSanityCost": 443.08,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 98.378
   },
   {
     "id": "30031",
@@ -893,7 +977,8 @@
         "itemSanityCost": 4.72,
         "dropRate": 2.54
       }
-    }
+    },
+    "sanityValue": 1.825
   },
   {
     "id": "30032",
@@ -924,7 +1009,8 @@
         "itemSanityCost": 9.87,
         "dropRate": 0.91
       }
-    }
+    },
+    "sanityValue": 5.53
   },
   {
     "id": "30033",
@@ -949,13 +1035,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "7-4",
-        "itemSanityCost": 32.39,
+        "itemSanityCost": 32.41,
         "dropRate": 0.56
       }
-    }
+    },
+    "sanityValue": 21.877
   },
   {
     "id": "30034",
@@ -997,10 +1084,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "6-4",
-        "itemSanityCost": 455.7,
+        "itemSanityCost": 451.35,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 91.563
   },
   {
     "id": "30041",
@@ -1011,10 +1099,11 @@
       "leastSanity": {
         "stageSanityCost": 6,
         "stageName": "1-3",
-        "itemSanityCost": 6.18,
+        "itemSanityCost": 6.17,
         "dropRate": 0.97
       }
-    }
+    },
+    "sanityValue": 2.372
   },
   {
     "id": "30042",
@@ -1045,7 +1134,8 @@
         "itemSanityCost": 12.3,
         "dropRate": 1.22
       }
-    }
+    },
+    "sanityValue": 7.171
   },
   {
     "id": "30043",
@@ -1073,16 +1163,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "7-18",
-        "itemSanityCost": 52.34,
+        "itemSanityCost": 52.66,
         "dropRate": 0.4
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "S4-1",
-        "itemSanityCost": 57.42,
-        "dropRate": 0.31
       }
-    }
+    },
+    "sanityValue": 28.439
   },
   {
     "id": "30044",
@@ -1124,16 +1209,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "5-5",
-        "itemSanityCost": 485.88,
+        "itemSanityCost": 488.68,
         "dropRate": 0.04
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "S4-1",
-        "itemSanityCost": 528.2,
-        "dropRate": 0.03
       }
-    }
+    },
+    "sanityValue": 112.325
   },
   {
     "id": "30051",
@@ -1144,10 +1224,11 @@
       "leastSanity": {
         "stageSanityCost": 12,
         "stageName": "S2-9",
-        "itemSanityCost": 6.18,
+        "itemSanityCost": 6.2,
         "dropRate": 1.94
       }
-    }
+    },
+    "sanityValue": 2.275
   },
   {
     "id": "30052",
@@ -1175,10 +1256,11 @@
       "leastSanity": {
         "stageSanityCost": 15,
         "stageName": "3-7",
-        "itemSanityCost": 12.24,
-        "dropRate": 1.23
+        "itemSanityCost": 12.25,
+        "dropRate": 1.22
       }
-    }
+    },
+    "sanityValue": 6.882
   },
   {
     "id": "30053",
@@ -1203,13 +1285,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "JT8-3",
-        "itemSanityCost": 40.07,
+        "itemSanityCost": 40.06,
         "dropRate": 0.45
       }
-    }
+    },
+    "sanityValue": 27.282
   },
   {
     "id": "30054",
@@ -1251,10 +1334,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "4-5",
-        "itemSanityCost": 499.63,
+        "itemSanityCost": 499.69,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 102.119
   },
   {
     "id": "30061",
@@ -1265,10 +1349,11 @@
       "leastSanity": {
         "stageSanityCost": 6,
         "stageName": "1-5",
-        "itemSanityCost": 8.04,
-        "dropRate": 0.75
+        "itemSanityCost": 8.07,
+        "dropRate": 0.74
       }
-    }
+    },
+    "sanityValue": 3.09
   },
   {
     "id": "30062",
@@ -1299,7 +1384,8 @@
         "itemSanityCost": 16.29,
         "dropRate": 0.92
       }
-    }
+    },
+    "sanityValue": 9.327
   },
   {
     "id": "30063",
@@ -1324,13 +1410,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "7-15",
-        "itemSanityCost": 53.97,
+        "itemSanityCost": 53.96,
         "dropRate": 0.33
       }
-    }
+    },
+    "sanityValue": 37.062
   },
   {
     "id": "30064",
@@ -1372,10 +1459,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "4-10",
-        "itemSanityCost": 672.51,
+        "itemSanityCost": 671.26,
         "dropRate": 0.03
       }
-    }
+    },
+    "sanityValue": 97.007
   },
   {
     "id": "30073",
@@ -1386,16 +1474,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "6-11",
-        "itemSanityCost": 42.61,
+        "itemSanityCost": 42.59,
         "dropRate": 0.49
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "4-4",
-        "itemSanityCost": 48.46,
-        "dropRate": 0.37
       }
-    }
+    },
+    "sanityValue": 24.021
   },
   {
     "id": "30074",
@@ -1434,13 +1517,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "4-4",
-        "itemSanityCost": 348.9,
+        "itemSanityCost": 349.87,
         "dropRate": 0.05
       }
-    }
+    },
+    "sanityValue": 79.219
   },
   {
     "id": "30083",
@@ -1451,16 +1535,11 @@
       "leastSanity": {
         "stageSanityCost": 15,
         "stageName": "3-2",
-        "itemSanityCost": 40.67,
+        "itemSanityCost": 40.63,
         "dropRate": 0.37
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "4-7",
-        "itemSanityCost": 60.17,
-        "dropRate": 0.3
       }
-    }
+    },
+    "sanityValue": 28.665
   },
   {
     "id": "30084",
@@ -1499,13 +1578,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "4-7",
-        "itemSanityCost": 457.34,
+        "itemSanityCost": 457.06,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 99.734
   },
   {
     "id": "30093",
@@ -1518,14 +1598,9 @@
         "stageName": "3-3",
         "itemSanityCost": 46.89,
         "dropRate": 0.32
-      },
-      "mostEfficient": {
-        "stageSanityCost": 21,
-        "stageName": "4-8",
-        "itemSanityCost": 60.6,
-        "dropRate": 0.35
       }
-    }
+    },
+    "sanityValue": 30.265
   },
   {
     "id": "30094",
@@ -1567,16 +1642,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "7-17",
-        "itemSanityCost": 430.97,
-        "dropRate": 0.05
-      },
-      "mostEfficient": {
-        "stageSanityCost": 21,
-        "stageName": "4-8",
-        "itemSanityCost": 434.31,
+        "itemSanityCost": 428.3,
         "dropRate": 0.05
       }
-    }
+    },
+    "sanityValue": 92.274
   },
   {
     "id": "30103",
@@ -1587,16 +1657,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "R8-9",
-        "itemSanityCost": 51.87,
+        "itemSanityCost": 51.91,
         "dropRate": 0.35
-      },
-      "mostEfficient": {
-        "stageSanityCost": 21,
-        "stageName": "4-9",
-        "itemSanityCost": 69.86,
-        "dropRate": 0.3
       }
-    }
+    },
+    "sanityValue": 36.308
   },
   {
     "id": "30104",
@@ -1635,13 +1700,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "4-9",
-        "itemSanityCost": 475.9,
+        "itemSanityCost": 476.61,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 93.269
   },
   {
     "id": "30115",
@@ -1678,7 +1744,8 @@
         "sortId": 100032
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 262.549
   },
   {
     "id": "30125",
@@ -1708,7 +1775,8 @@
         "sortId": 100004
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 240.699
   },
   {
     "id": "30135",
@@ -1745,7 +1813,8 @@
         "sortId": 100010
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 270.531
   },
   {
     "id": "30145",
@@ -1782,7 +1851,8 @@
         "sortId": 100038
       }
     ],
-    "yield": 1
+    "yield": 1,
+    "sanityValue": 169.582
   },
   {
     "id": "31013",
@@ -1790,13 +1860,14 @@
     "tier": 3,
     "sortId": 100037,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "JT8-2",
-        "itemSanityCost": 63.1,
+        "itemSanityCost": 63.13,
         "dropRate": 0.33
       }
-    }
+    },
+    "sanityValue": 31.921
   },
   {
     "id": "31014",
@@ -1838,16 +1909,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "7-8",
-        "itemSanityCost": 408,
+        "itemSanityCost": 405.86,
         "dropRate": 0.04
-      },
-      "mostEfficient": {
-        "stageSanityCost": 21,
-        "stageName": "JT8-2",
-        "itemSanityCost": 438.9,
-        "dropRate": 0.05
       }
-    }
+    },
+    "sanityValue": 83.427
   },
   {
     "id": "31023",
@@ -1860,14 +1926,9 @@
         "stageName": "S3-6",
         "itemSanityCost": 37.63,
         "dropRate": 0.4
-      },
-      "mostEfficient": {
-        "stageSanityCost": 18,
-        "stageName": "R8-7",
-        "itemSanityCost": 54.54,
-        "dropRate": 0.33
       }
-    }
+    },
+    "sanityValue": 26.56
   },
   {
     "id": "31024",
@@ -1906,13 +1967,14 @@
     ],
     "yield": 1,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "R8-7",
-        "itemSanityCost": 431.34,
+        "itemSanityCost": 428.81,
         "dropRate": 0.04
       }
-    }
+    },
+    "sanityValue": 90.394
   },
   {
     "id": "31033",
@@ -1920,13 +1982,14 @@
     "tier": 3,
     "sortId": 100042,
     "stages": {
-      "mostEfficient": {
+      "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "R8-11",
-        "itemSanityCost": 39.27,
+        "itemSanityCost": 39.36,
         "dropRate": 0.53
       }
-    }
+    },
+    "sanityValue": 20.838
   },
   {
     "id": "31034",
@@ -1968,22 +2031,18 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "S5-9",
-        "itemSanityCost": 535.13,
-        "dropRate": 0.03
-      },
-      "mostEfficient": {
-        "stageSanityCost": 21,
-        "stageName": "R8-11",
-        "itemSanityCost": 724.03,
+        "itemSanityCost": 534.57,
         "dropRate": 0.03
       }
-    }
+    },
+    "sanityValue": 96.663
   },
   {
     "id": "32001",
     "name": "Chip Catalyst",
     "tier": 4,
-    "sortId": 400001
+    "sortId": 400001,
+    "sanityValue": 0
   },
   {
     "id": "Crystal Component",

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -12,6 +12,12 @@
         "stageName": "0-3",
         "itemSanityCost": 1.35,
         "dropRate": 4.43
+      },
+      "mostEfficient": {
+        "stageSanityCost": 6,
+        "stageName": "1-7",
+        "itemSanityCost": 4.87,
+        "dropRate": 1.23
       }
     },
     "sanityValue": 0.607
@@ -773,7 +779,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 6,
         "stageName": "1-7",
         "itemSanityCost": 4.82,
@@ -921,6 +927,12 @@
         "stageName": "2-5",
         "itemSanityCost": 32.64,
         "dropRate": 0.37
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "4-2",
+        "itemSanityCost": 46.05,
+        "dropRate": 0.39
       }
     },
     "sanityValue": 22.385
@@ -966,6 +978,12 @@
         "stageSanityCost": 18,
         "stageName": "5-2",
         "itemSanityCost": 443.08,
+        "dropRate": 0.04
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "4-2",
+        "itemSanityCost": 453.05,
         "dropRate": 0.04
       }
     },
@@ -1041,7 +1059,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "7-4",
         "itemSanityCost": 32.41,
@@ -1227,7 +1245,7 @@
       "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "S4-1",
-        "itemSanityCost": 528.29,
+        "itemSanityCost": 528.3,
         "dropRate": 0.03
       }
     },
@@ -1303,7 +1321,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "JT8-3",
         "itemSanityCost": 40.06,
@@ -1428,7 +1446,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "7-15",
         "itemSanityCost": 53.96,
@@ -1494,6 +1512,12 @@
         "stageName": "6-11",
         "itemSanityCost": 42.6,
         "dropRate": 0.49
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "4-4",
+        "itemSanityCost": 48.46,
+        "dropRate": 0.37
       }
     },
     "sanityValue": 24.083
@@ -1535,7 +1559,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "4-4",
         "itemSanityCost": 349.64,
@@ -1555,6 +1579,12 @@
         "stageName": "3-2",
         "itemSanityCost": 40.63,
         "dropRate": 0.37
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "4-7",
+        "itemSanityCost": 60.2,
+        "dropRate": 0.3
       }
     },
     "sanityValue": 28.84
@@ -1596,7 +1626,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "4-7",
         "itemSanityCost": 457.32,
@@ -1615,6 +1645,12 @@
         "stageSanityCost": 15,
         "stageName": "3-3",
         "itemSanityCost": 46.89,
+        "dropRate": 0.32
+      },
+      "mostEfficient": {
+        "stageSanityCost": 21,
+        "stageName": "7-17",
+        "itemSanityCost": 65.56,
         "dropRate": 0.32
       }
     },
@@ -1657,7 +1693,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 21,
         "stageName": "7-17",
         "itemSanityCost": 428.3,
@@ -1677,6 +1713,12 @@
         "stageName": "R8-9",
         "itemSanityCost": 51.93,
         "dropRate": 0.35
+      },
+      "mostEfficient": {
+        "stageSanityCost": 21,
+        "stageName": "4-9",
+        "itemSanityCost": 69.88,
+        "dropRate": 0.3
       }
     },
     "sanityValue": 36.345
@@ -1718,7 +1760,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 21,
         "stageName": "4-9",
         "itemSanityCost": 476.74,
@@ -1878,7 +1920,7 @@
     "tier": 3,
     "sortId": 100037,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 21,
         "stageName": "JT8-2",
         "itemSanityCost": 63.11,
@@ -1929,6 +1971,12 @@
         "stageName": "7-8",
         "itemSanityCost": 402.7,
         "dropRate": 0.04
+      },
+      "mostEfficient": {
+        "stageSanityCost": 21,
+        "stageName": "JT8-2",
+        "itemSanityCost": 435.33,
+        "dropRate": 0.05
       }
     },
     "sanityValue": 83.55
@@ -1944,6 +1992,12 @@
         "stageName": "S3-6",
         "itemSanityCost": 37.63,
         "dropRate": 0.4
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "R8-7",
+        "itemSanityCost": 54.51,
+        "dropRate": 0.33
       }
     },
     "sanityValue": 27.218
@@ -1985,7 +2039,7 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "R8-7",
         "itemSanityCost": 428.89,
@@ -2000,7 +2054,7 @@
     "tier": 3,
     "sortId": 100042,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 21,
         "stageName": "R8-11",
         "itemSanityCost": 39.36,
@@ -2050,6 +2104,12 @@
         "stageSanityCost": 18,
         "stageName": "S5-9",
         "itemSanityCost": 536.6,
+        "dropRate": 0.03
+      },
+      "mostEfficient": {
+        "stageSanityCost": 21,
+        "stageName": "R8-11",
+        "itemSanityCost": 728.13,
         "dropRate": 0.03
       }
     },

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -81,7 +81,7 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-C-1",
         "itemSanityCost": 36.11,
@@ -106,7 +106,7 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-C-2",
         "itemSanityCost": 73.23,
@@ -155,10 +155,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-D-1",
-        "itemSanityCost": 35.85,
+        "itemSanityCost": 35.9,
         "dropRate": 0.5
       }
     },
@@ -180,10 +180,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-D-2",
-        "itemSanityCost": 71.87,
+        "itemSanityCost": 71.84,
         "dropRate": 0.5
       }
     },
@@ -229,10 +229,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-A-1",
-        "itemSanityCost": 34.89,
+        "itemSanityCost": 35,
         "dropRate": 0.5
       }
     },
@@ -254,10 +254,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-A-2",
-        "itemSanityCost": 72.08,
+        "itemSanityCost": 72.04,
         "dropRate": 0.5
       }
     },
@@ -303,10 +303,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-B-1",
-        "itemSanityCost": 37.21,
+        "itemSanityCost": 37.38,
         "dropRate": 0.5
       }
     },
@@ -328,10 +328,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-B-2",
-        "itemSanityCost": 71.9,
+        "itemSanityCost": 71.84,
         "dropRate": 0.5
       }
     },
@@ -377,10 +377,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-B-1",
-        "itemSanityCost": 34.86,
+        "itemSanityCost": 34.72,
         "dropRate": 0.5
       }
     },
@@ -402,10 +402,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-B-2",
-        "itemSanityCost": 72.1,
+        "itemSanityCost": 72.16,
         "dropRate": 0.5
       }
     },
@@ -451,10 +451,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-A-1",
-        "itemSanityCost": 37.18,
+        "itemSanityCost": 37.06,
         "dropRate": 0.5
       }
     },
@@ -476,10 +476,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-A-2",
-        "itemSanityCost": 71.92,
+        "itemSanityCost": 71.96,
         "dropRate": 0.5
       }
     },
@@ -525,7 +525,7 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-C-1",
         "itemSanityCost": 35.89,
@@ -550,7 +550,7 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-C-2",
         "itemSanityCost": 70.81,
@@ -599,10 +599,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 18,
         "stageName": "PR-D-1",
-        "itemSanityCost": 36.15,
+        "itemSanityCost": 36.1,
         "dropRate": 0.5
       }
     },
@@ -624,10 +624,10 @@
     ],
     "yield": 2,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 36,
         "stageName": "PR-D-2",
-        "itemSanityCost": 72.13,
+        "itemSanityCost": 72.16,
         "dropRate": 0.5
       }
     },
@@ -670,7 +670,7 @@
         "dropRate": 5
       }
     },
-    "sanityValue": 1.544
+    "sanityValue": 1.543
   },
   {
     "id": "3302",
@@ -693,9 +693,15 @@
         "stageName": "CA-3",
         "itemSanityCost": 6.67,
         "dropRate": 3
+      },
+      "mostEfficient": {
+        "stageSanityCost": 30,
+        "stageName": "CA-5",
+        "itemSanityCost": 19.95,
+        "dropRate": 1.5
       }
     },
-    "sanityValue": 3.958
+    "sanityValue": 3.957
   },
   {
     "id": "3303",
@@ -713,14 +719,14 @@
     ],
     "yield": 1,
     "stages": {
-      "leastSanity": {
+      "mostEfficient": {
         "stageSanityCost": 30,
         "stageName": "CA-5",
         "itemSanityCost": 15,
         "dropRate": 2
       }
     },
-    "sanityValue": 10.148
+    "sanityValue": 10.147
   },
   {
     "id": "4001",
@@ -742,7 +748,7 @@
         "dropRate": 3.7
       }
     },
-    "sanityValue": 1.104
+    "sanityValue": 1.103
   },
   {
     "id": "30012",
@@ -806,7 +812,7 @@
         "dropRate": 0.42
       }
     },
-    "sanityValue": 16.586
+    "sanityValue": 16.588
   },
   {
     "id": "30014",
@@ -838,7 +844,7 @@
         "dropRate": 0.06
       }
     },
-    "sanityValue": 62.852
+    "sanityValue": 62.848
   },
   {
     "id": "30021",
@@ -881,7 +887,7 @@
       "leastSanity": {
         "stageSanityCost": 15,
         "stageName": "S3-1",
-        "itemSanityCost": 9.9,
+        "itemSanityCost": 9.91,
         "dropRate": 1.51
       }
     },
@@ -913,11 +919,11 @@
       "leastSanity": {
         "stageSanityCost": 12,
         "stageName": "2-5",
-        "itemSanityCost": 32.65,
+        "itemSanityCost": 32.64,
         "dropRate": 0.37
       }
     },
-    "sanityValue": 22.383
+    "sanityValue": 22.385
   },
   {
     "id": "30024",
@@ -963,7 +969,7 @@
         "dropRate": 0.04
       }
     },
-    "sanityValue": 98.378
+    "sanityValue": 98.441
   },
   {
     "id": "30031",
@@ -978,7 +984,7 @@
         "dropRate": 2.54
       }
     },
-    "sanityValue": 1.825
+    "sanityValue": 1.829
   },
   {
     "id": "30032",
@@ -1010,7 +1016,7 @@
         "dropRate": 0.91
       }
     },
-    "sanityValue": 5.53
+    "sanityValue": 5.543
   },
   {
     "id": "30033",
@@ -1042,7 +1048,7 @@
         "dropRate": 0.56
       }
     },
-    "sanityValue": 21.877
+    "sanityValue": 21.93
   },
   {
     "id": "30034",
@@ -1088,7 +1094,7 @@
         "dropRate": 0.04
       }
     },
-    "sanityValue": 91.563
+    "sanityValue": 91.433
   },
   {
     "id": "30041",
@@ -1103,7 +1109,7 @@
         "dropRate": 0.97
       }
     },
-    "sanityValue": 2.372
+    "sanityValue": 2.363
   },
   {
     "id": "30042",
@@ -1135,7 +1141,7 @@
         "dropRate": 1.22
       }
     },
-    "sanityValue": 7.171
+    "sanityValue": 7.144
   },
   {
     "id": "30043",
@@ -1163,11 +1169,17 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "7-18",
-        "itemSanityCost": 52.66,
+        "itemSanityCost": 52.42,
         "dropRate": 0.4
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "S4-1",
+        "itemSanityCost": 57.52,
+        "dropRate": 0.31
       }
     },
-    "sanityValue": 28.439
+    "sanityValue": 28.335
   },
   {
     "id": "30044",
@@ -1209,11 +1221,17 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "5-5",
-        "itemSanityCost": 488.68,
+        "itemSanityCost": 489.35,
         "dropRate": 0.04
+      },
+      "mostEfficient": {
+        "stageSanityCost": 18,
+        "stageName": "S4-1",
+        "itemSanityCost": 528.29,
+        "dropRate": 0.03
       }
     },
-    "sanityValue": 112.325
+    "sanityValue": 112.014
   },
   {
     "id": "30051",
@@ -1228,7 +1246,7 @@
         "dropRate": 1.94
       }
     },
-    "sanityValue": 2.275
+    "sanityValue": 2.251
   },
   {
     "id": "30052",
@@ -1260,7 +1278,7 @@
         "dropRate": 1.22
       }
     },
-    "sanityValue": 6.882
+    "sanityValue": 6.809
   },
   {
     "id": "30053",
@@ -1292,7 +1310,7 @@
         "dropRate": 0.45
       }
     },
-    "sanityValue": 27.282
+    "sanityValue": 26.993
   },
   {
     "id": "30054",
@@ -1338,7 +1356,7 @@
         "dropRate": 0.04
       }
     },
-    "sanityValue": 102.119
+    "sanityValue": 101.707
   },
   {
     "id": "30061",
@@ -1353,7 +1371,7 @@
         "dropRate": 0.74
       }
     },
-    "sanityValue": 3.09
+    "sanityValue": 3.078
   },
   {
     "id": "30062",
@@ -1381,11 +1399,11 @@
       "leastSanity": {
         "stageSanityCost": 15,
         "stageName": "S3-4",
-        "itemSanityCost": 16.29,
+        "itemSanityCost": 16.3,
         "dropRate": 0.92
       }
     },
-    "sanityValue": 9.327
+    "sanityValue": 9.29
   },
   {
     "id": "30063",
@@ -1417,7 +1435,7 @@
         "dropRate": 0.33
       }
     },
-    "sanityValue": 37.062
+    "sanityValue": 36.917
   },
   {
     "id": "30064",
@@ -1463,7 +1481,7 @@
         "dropRate": 0.03
       }
     },
-    "sanityValue": 97.007
+    "sanityValue": 96.785
   },
   {
     "id": "30073",
@@ -1474,11 +1492,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "6-11",
-        "itemSanityCost": 42.59,
+        "itemSanityCost": 42.6,
         "dropRate": 0.49
       }
     },
-    "sanityValue": 24.021
+    "sanityValue": 24.083
   },
   {
     "id": "30074",
@@ -1520,11 +1538,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "4-4",
-        "itemSanityCost": 349.87,
+        "itemSanityCost": 349.64,
         "dropRate": 0.05
       }
     },
-    "sanityValue": 79.219
+    "sanityValue": 79.309
   },
   {
     "id": "30083",
@@ -1539,7 +1557,7 @@
         "dropRate": 0.37
       }
     },
-    "sanityValue": 28.665
+    "sanityValue": 28.84
   },
   {
     "id": "30084",
@@ -1581,11 +1599,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "4-7",
-        "itemSanityCost": 457.06,
+        "itemSanityCost": 457.32,
         "dropRate": 0.04
       }
     },
-    "sanityValue": 99.734
+    "sanityValue": 100.189
   },
   {
     "id": "30093",
@@ -1600,7 +1618,7 @@
         "dropRate": 0.32
       }
     },
-    "sanityValue": 30.265
+    "sanityValue": 30.195
   },
   {
     "id": "30094",
@@ -1646,7 +1664,7 @@
         "dropRate": 0.05
       }
     },
-    "sanityValue": 92.274
+    "sanityValue": 91.944
   },
   {
     "id": "30103",
@@ -1657,11 +1675,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "R8-9",
-        "itemSanityCost": 51.91,
+        "itemSanityCost": 51.93,
         "dropRate": 0.35
       }
     },
-    "sanityValue": 36.308
+    "sanityValue": 36.345
   },
   {
     "id": "30104",
@@ -1703,11 +1721,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "4-9",
-        "itemSanityCost": 476.61,
+        "itemSanityCost": 476.74,
         "dropRate": 0.04
       }
     },
-    "sanityValue": 93.269
+    "sanityValue": 93.01
   },
   {
     "id": "30115",
@@ -1745,7 +1763,7 @@
       }
     ],
     "yield": 1,
-    "sanityValue": 262.549
+    "sanityValue": 261.805
   },
   {
     "id": "30125",
@@ -1776,7 +1794,7 @@
       }
     ],
     "yield": 1,
-    "sanityValue": 240.699
+    "sanityValue": 240.638
   },
   {
     "id": "30135",
@@ -1814,7 +1832,7 @@
       }
     ],
     "yield": 1,
-    "sanityValue": 270.531
+    "sanityValue": 270.379
   },
   {
     "id": "30145",
@@ -1852,7 +1870,7 @@
       }
     ],
     "yield": 1,
-    "sanityValue": 169.582
+    "sanityValue": 170.792
   },
   {
     "id": "31013",
@@ -1863,11 +1881,11 @@
       "leastSanity": {
         "stageSanityCost": 21,
         "stageName": "JT8-2",
-        "itemSanityCost": 63.13,
+        "itemSanityCost": 63.11,
         "dropRate": 0.33
       }
     },
-    "sanityValue": 31.921
+    "sanityValue": 31.501
   },
   {
     "id": "31014",
@@ -1909,11 +1927,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "7-8",
-        "itemSanityCost": 405.86,
+        "itemSanityCost": 402.7,
         "dropRate": 0.04
       }
     },
-    "sanityValue": 83.427
+    "sanityValue": 83.55
   },
   {
     "id": "31023",
@@ -1928,7 +1946,7 @@
         "dropRate": 0.4
       }
     },
-    "sanityValue": 26.56
+    "sanityValue": 27.218
   },
   {
     "id": "31024",
@@ -1970,11 +1988,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "R8-7",
-        "itemSanityCost": 428.81,
+        "itemSanityCost": 428.89,
         "dropRate": 0.04
       }
     },
-    "sanityValue": 90.394
+    "sanityValue": 90.827
   },
   {
     "id": "31033",
@@ -1989,7 +2007,7 @@
         "dropRate": 0.53
       }
     },
-    "sanityValue": 20.838
+    "sanityValue": 21.603
   },
   {
     "id": "31034",
@@ -2031,11 +2049,11 @@
       "leastSanity": {
         "stageSanityCost": 18,
         "stageName": "S5-9",
-        "itemSanityCost": 534.57,
+        "itemSanityCost": 536.6,
         "dropRate": 0.03
       }
     },
-    "sanityValue": 96.663
+    "sanityValue": 98.421
   },
   {
     "id": "32001",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,6 +3280,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yoga-layout@1.9.2":
   version "1.9.2"
   resolved "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
@@ -3685,6 +3692,13 @@ address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -4489,7 +4503,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^4.0.0:
+bl@^4.0.0, bl@^4.0.3:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -4872,7 +4886,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.2, buffer@^5.5.0, buffer@^5.7.0:
+buffer@^5.0.2, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.7.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -6414,6 +6428,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@4.3.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -6434,13 +6455,6 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -6692,6 +6706,11 @@ devcert@^1.1.3:
     sudo-prompt "^8.2.0"
     tmp "^0.0.33"
     tslib "^1.10.0"
+
+devtools-protocol@0.0.883894:
+  version "0.0.883894"
+  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.883894.tgz#d403f2c75cd6d71c916aee8dde9258da988a4da9"
+  integrity sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==
 
 dicer@0.2.5:
   version "0.2.5"
@@ -7022,7 +7041,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -7795,6 +7814,17 @@ extract-files@9.0.0:
   resolved "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
   integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
 
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extract-zip@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
@@ -8219,6 +8249,11 @@ fs-capacitor@^6.1.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz#fa79ac6576629163cb84561995602d8999afb7f5"
   integrity sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-exists-cached@1.0.0, fs-exists-cached@^1.0.0:
   version "1.0.0"
@@ -9705,6 +9740,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -13022,6 +13065,13 @@ pirates@^4.0.0, pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
@@ -13035,13 +13085,6 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pkg-dir@^5.0.0:
   version "5.0.0"
@@ -13568,6 +13611,11 @@ process@^0.11.10, process@~0.11.0:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -13653,6 +13701,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
+proxy-from-env@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -13726,6 +13779,24 @@ pupa@^2.1.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
+
+puppeteer@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-10.1.0.tgz#6ee1d7e30401a967f4403bd42ace9e51e399504f"
+  integrity sha512-bsyDHbFBvbofZ63xqF7hMhuKBX1h4WsqFIAoh1GuHr/Y9cewh+EFNAOdqWSkQRHLiBU/MY6M+8PUnXXjAPtuSg==
+  dependencies:
+    debug "4.3.1"
+    devtools-protocol "0.0.883894"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    node-fetch "2.6.1"
+    pkg-dir "4.2.0"
+    progress "2.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.0.0"
+    unbzip2-stream "1.3.3"
+    ws "7.4.6"
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
@@ -14631,17 +14702,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -15846,6 +15917,27 @@ tapable@^2.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
+tar-fs@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
+  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp "^0.5.1"
+    pump "^3.0.0"
+    tar-stream "^2.0.0"
+
+tar-stream@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar@^6.0.2:
   version "6.1.0"
   resolved "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
@@ -16334,6 +16426,14 @@ unbox-primitive@^1.0.0:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+unbzip2-stream@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
+  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -17245,6 +17345,11 @@ ws@7.4.5, ws@^7.3.0, ws@~7.4.2:
   version "7.4.5"
   resolved "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
   integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
Item sanity values are pulled from Luzark's LP solver with default settings.

We can use the LP planner output for the set of efficient stages as well, meaning we don't have to hardcode them anymore.