### PR TITLE
Render page titles during SSR

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@
 
 module.exports = {
   siteMetadata: {
-    title: "Arknights Tools",
+    siteTitle: "Arknights Tools",
     siteUrl: "https://samidare.io/arknights",
     description:
       "A collection of tools for Arknights, a tower defense mobile game by Hypergryph/Yostar",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,24 @@ module.exports = {
     siteUrl: "https://samidare.io/arknights",
     description:
       "A collection of tools for Arknights, a tower defense mobile game by Hypergryph/Yostar",
+    pages: [
+      {
+        slug: "/planner",
+        pageTitle: "Operator Planner",
+      },
+      {
+        slug: "/recruitment",
+        pageTitle: "Recruitment Calculator",
+      },
+      {
+        slug: "/gacha",
+        pageTitle: "Pull Probability Calculator",
+      },
+      {
+        slug: "/leveling",
+        pageTitle: "Leveling Costs",
+      },
+    ],
   },
   pathPrefix: "/arknights",
   plugins: [
@@ -24,5 +42,12 @@ module.exports = {
       },
     },
     "gatsby-plugin-netlify",
+    {
+      resolve: `gatsby-plugin-page-creator`,
+      options: {
+        path: `${__dirname}/src/pages`,
+        ignore: ["*"],
+      },
+    },
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,25 @@
+const paths = {
+  "/planner": "Operator Planner",
+  "/recruitment": "Recruitment Calculator",
+  "/gacha": "Pull Probability Calculator",
+  "/leveling": "Leveling Costs",
+  "/base": "Base Rotation Visualizer",
+};
+
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage, deletePage } = actions;
+  deletePage(page);
+  const pathNoTrailingBackslash = page.path.slice(0, -1);
+  const pageTitle = paths[pathNoTrailingBackslash] || "";
+  console.log(
+    "creating page:",
+    createPage({
+      ...page,
+      context: {
+        ...page.context,
+        pageTitle,
+        paths,
+      },
+    })
+  );
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,25 +1,35 @@
-const paths = {
-  "/planner": "Operator Planner",
-  "/recruitment": "Recruitment Calculator",
-  "/gacha": "Pull Probability Calculator",
-  "/leveling": "Leveling Costs",
-  "/base": "Base Rotation Visualizer",
-};
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require("path");
 
-exports.onCreatePage = ({ page, actions }) => {
-  const { createPage, deletePage } = actions;
-  deletePage(page);
-  const pathNoTrailingBackslash = page.path.slice(0, -1);
-  const pageTitle = paths[pathNoTrailingBackslash] || "";
-  console.log(
-    "creating page:",
-    createPage({
-      ...page,
-      context: {
-        ...page.context,
-        pageTitle,
-        paths,
-      },
-    })
-  );
+exports.createPages = ({ graphql, actions }) => {
+  const { createPage } = actions;
+  return graphql(
+    `
+      query {
+        site {
+          siteMetadata {
+            pages {
+              slug
+              pageTitle
+            }
+          }
+        }
+      }
+    `
+  ).then((result) => {
+    if (result.errors) {
+      throw result.errors;
+    }
+
+    result.data.site.siteMetadata.pages.forEach((page) => {
+      const pageComponent = path.resolve(`src/pages/${page.slug}.tsx`);
+      createPage({
+        path: page.slug,
+        component: pageComponent,
+        context: {
+          pageTitle: page.pageTitle,
+        },
+      });
+    });
+  });
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gatsby-plugin-layout": "^2.0.0",
     "gatsby-plugin-material-ui": "^2.1.10",
     "gatsby-plugin-netlify": "^3.0.0",
+    "gatsby-plugin-page-creator": "^3.8.0",
     "gatsby-plugin-react-helmet": "^4.3.0",
     "gatsby-source-filesystem": "^3.0.0",
     "gatsby-theme-material-ui": "^2.0.1",

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -115,7 +115,6 @@ interface LayoutProps {
 }
 
 function Layout(props: LayoutProps): React.ReactElement {
-  console.log(props);
   const { children, pageContext } = props;
   const { pageTitle, paths } = pageContext;
   const classes = useStyles();

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -107,6 +107,7 @@ function ListItemLink({ to, linkText }: { to: string; linkText: string }) {
 }
 
 interface LayoutProps {
+  uri: string;
   children: React.ReactNode;
   pageContext: {
     pageTitle: string;
@@ -114,14 +115,15 @@ interface LayoutProps {
 }
 
 function Layout(props: LayoutProps): React.ReactElement {
-  const { children, pageContext } = props;
+  const { uri, children, pageContext } = props;
   const { pageTitle } = pageContext;
   const classes = useStyles();
-  const { title, description, pages } = useStaticQuery(graphql`
+  const { siteTitle, siteUrl, description, pages } = useStaticQuery(graphql`
     query {
       site {
         siteMetadata {
-          title
+          siteTitle
+          siteUrl
           description
           pages {
             slug
@@ -131,6 +133,7 @@ function Layout(props: LayoutProps): React.ReactElement {
       }
     }
   `).site.siteMetadata;
+  const title = pageTitle ? `${pageTitle} · ${siteTitle}` : siteTitle;
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
@@ -146,7 +149,7 @@ function Layout(props: LayoutProps): React.ReactElement {
         component="h1"
         variant="h5"
       >
-        {title}
+        {siteTitle}
       </Typography>
       <Divider />
       <List>
@@ -175,8 +178,12 @@ function Layout(props: LayoutProps): React.ReactElement {
     <NetlifyLoginContext.Provider value={{ currentUser, setCurrentUser }}>
       <Helmet>
         <html lang="en" />
-        <title>{pageTitle ? `${pageTitle} - ${title}` : title}</title>
+        <title>{title}</title>
         <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={favicon} />
+        <meta property="og:url" content={`${siteUrl}${uri}`} />
         <link rel="icon" type="image/x-icon" href={favicon} />
       </Helmet>
       <CssBaseline />

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -163,7 +163,9 @@ function Layout(props: LayoutProps): React.ReactElement {
     <NetlifyLoginContext.Provider value={{ currentUser, setCurrentUser }}>
       <Helmet>
         <html lang="en" />
-        <title>{title}</title>
+        <title>
+          {pageTitle} - {title}
+        </title>
         <meta name="description" content={description} />
         <link rel="icon" type="image/x-icon" href={favicon} />
       </Helmet>

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -190,7 +190,7 @@ function Layout(props: LayoutProps): React.ReactElement {
       <div className={classes.appWrapper}>
         <div className={classes.appContainer}>
           <nav className={classes.drawer}>
-            {/* The implementation can be swapped with js to avoid SEO duplication of paths. */}
+            {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
             <Hidden lgUp implementation="css">
               <Drawer
                 container={container}

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -78,20 +78,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const links = {
-  "/planner": "Operator Planner",
-  "/recruitment": "Recruitment Calculator",
-  "/gacha": "Pull Probability Calculator",
-  "/leveling": "Leveling Costs",
-};
-
-function getPageTitle(title: string, uri: string): string | undefined {
-  const subpage = Object.entries(links).find(([pageUri, _]) =>
-    uri.endsWith(pageUri)
-  );
-  return subpage?.[1];
-}
-
 const useLinkStyles = makeStyles((theme) => ({
   link: {
     color: theme.palette.text.primary,
@@ -122,11 +108,16 @@ function ListItemLink({ to, primary }: { to: string; primary: string }) {
 
 interface LayoutProps {
   children: React.ReactNode;
-  uri: string;
+  pageContext: {
+    pageTitle: string;
+    paths: Record<string, string>;
+  };
 }
 
 function Layout(props: LayoutProps): React.ReactElement {
-  const { children, uri } = props;
+  console.log(props);
+  const { children, pageContext } = props;
+  const { pageTitle, paths } = pageContext;
   const classes = useStyles();
   const { title, description } = useStaticQuery(graphql`
     query {
@@ -139,7 +130,6 @@ function Layout(props: LayoutProps): React.ReactElement {
     }
   `).site.siteMetadata;
   const theme = useTheme();
-  const pageTitle = getPageTitle(title, uri);
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
 
@@ -158,7 +148,7 @@ function Layout(props: LayoutProps): React.ReactElement {
       </Typography>
       <Divider />
       <List>
-        {Object.entries(links).map(([pageUri, pageName]) => (
+        {Object.entries(paths).map(([pageUri, pageName]) => (
           <ListItemLink key={pageUri} to={pageUri} primary={pageName} />
         ))}
       </List>
@@ -182,7 +172,7 @@ function Layout(props: LayoutProps): React.ReactElement {
       <div className={classes.appWrapper}>
         <div className={classes.appContainer}>
           <nav className={classes.drawer}>
-            {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
+            {/* The implementation can be swapped with js to avoid SEO duplication of paths. */}
             <Hidden lgUp implementation="css">
               <Drawer
                 container={container}

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -87,7 +87,7 @@ const useLinkStyles = makeStyles((theme) => ({
   },
 }));
 
-function ListItemLink({ to, primary }: { to: string; primary: string }) {
+function ListItemLink({ to, linkText }: { to: string; linkText: string }) {
   const classes = useLinkStyles();
   const renderLink = React.useMemo(
     () =>
@@ -101,7 +101,7 @@ function ListItemLink({ to, primary }: { to: string; primary: string }) {
 
   return (
     <ListItem button component={renderLink}>
-      <ListItemText className={classes.link} primary={primary} />
+      <ListItemText className={classes.link} primary={linkText} />
     </ListItem>
   );
 }
@@ -110,20 +110,23 @@ interface LayoutProps {
   children: React.ReactNode;
   pageContext: {
     pageTitle: string;
-    paths: Record<string, string>;
   };
 }
 
 function Layout(props: LayoutProps): React.ReactElement {
   const { children, pageContext } = props;
-  const { pageTitle, paths } = pageContext;
+  const { pageTitle } = pageContext;
   const classes = useStyles();
-  const { title, description } = useStaticQuery(graphql`
+  const { title, description, pages } = useStaticQuery(graphql`
     query {
       site {
         siteMetadata {
           title
           description
+          pages {
+            slug
+            pageTitle
+          }
         }
       }
     }
@@ -147,9 +150,18 @@ function Layout(props: LayoutProps): React.ReactElement {
       </Typography>
       <Divider />
       <List>
-        {Object.entries(paths).map(([pageUri, pageName]) => (
-          <ListItemLink key={pageUri} to={pageUri} primary={pageName} />
-        ))}
+        {pages.map(
+          ({
+            slug,
+            pageTitle: linkedPageTitle,
+          }: {
+            // eslint-disable-next-line react/no-unused-prop-types
+            slug: string;
+            pageTitle: string;
+          }) => (
+            <ListItemLink key={slug} to={slug} linkText={linkedPageTitle} />
+          )
+        )}
       </List>
     </>
   );
@@ -163,9 +175,7 @@ function Layout(props: LayoutProps): React.ReactElement {
     <NetlifyLoginContext.Provider value={{ currentUser, setCurrentUser }}>
       <Helmet>
         <html lang="en" />
-        <title>
-          {pageTitle} - {title}
-        </title>
+        <title>{pageTitle ? `${pageTitle} - ${title}` : title}</title>
         <meta name="description" content={description} />
         <link rel="icon" type="image/x-icon" href={favicon} />
       </Helmet>

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -24,7 +24,6 @@ import { Link as GatsbyLink } from "gatsby-theme-material-ui";
 import netlifyIdentity, { User } from "netlify-identity-widget";
 import AppFooter from "../components/AppFooter";
 import favicon from "../data/images/favicon.ico";
-import NetlifyLogin from "./components/NetlifyLogin";
 import NetlifyLoginContext from "./components/NetlifyLoginContext";
 
 const drawerWidth = 220;
@@ -239,7 +238,6 @@ function Layout(props: LayoutProps): React.ReactElement {
               >
                 {pageTitle}
               </Typography>
-              {/* <NetlifyLogin /> */}
             </Toolbar>
           </AppBar>
           <Container className={classes.content} component="main" maxWidth="lg">

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.14.0":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+  dependencies:
+    "@babel/highlight" "^7.14.5"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.13.15", "@babel/compat-data@^7.13.8", "@babel/compat-data@^7.14.0":
   version "7.14.0"
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz#a901128bce2ad02565df95e6ecbf195cf9465919"
@@ -353,6 +360,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
   integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
@@ -383,6 +395,15 @@
   integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -1365,6 +1386,13 @@
   version "7.14.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.14.0":
+  version "7.14.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -8428,6 +8456,20 @@ gatsby-core-utils@^2.4.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-2.8.0.tgz#e6d2e6e56609c4fcef5ba6fbf29ad863dc7bb8d2"
+  integrity sha512-CadvILN4ZyYMYQAp+haxSgE/0k5zIu6y2WcqVSJaQLmmWq0o49Gv4CftVKOEXOtXaN0DEr9e4wWFVBRAYaRHGA==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    file-type "^16.2.0"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-1.4.0.tgz#49b9b6d617dbba3a032bfbc8dfd315754d63cfe3"
@@ -8466,6 +8508,20 @@ gatsby-page-utils@^1.4.0:
     chokidar "^3.5.1"
     fs-exists-cached "^1.0.0"
     gatsby-core-utils "^2.4.0"
+    glob "^7.1.6"
+    lodash "^4.17.21"
+    micromatch "^4.0.2"
+
+gatsby-page-utils@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-1.8.0.tgz#1bada55380f19421272feba8ccc741c651eb42d8"
+  integrity sha512-5fa5JbrHPiVDrBtkjoZySdClTUfmYBGg5OSMF2d/mFXEh8NCjSQK8EmosHO4u7uwLYT/gnb+BwsoVkuXYt+hHQ==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+    bluebird "^3.7.2"
+    chokidar "^3.5.1"
+    fs-exists-cached "^1.0.0"
+    gatsby-core-utils "^2.8.0"
     glob "^7.1.6"
     lodash "^4.17.21"
     micromatch "^4.0.2"
@@ -8527,6 +8583,21 @@ gatsby-plugin-page-creator@^3.4.0:
     gatsby-core-utils "^2.4.0"
     gatsby-page-utils "^1.4.0"
     gatsby-telemetry "^2.4.0"
+    globby "^11.0.3"
+    lodash "^4.17.21"
+
+gatsby-plugin-page-creator@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-3.8.0.tgz#314fe8bd2b55500100827079c291d0f86edb2bf2"
+  integrity sha512-6H+7+74f8rHay8V6EF80/ucDUREjaqCfrW5KSjAYxrc7uh8s5QNeumgNixQUAofnZQOCLTiyw1C3lOQnUVL4Xg==
+  dependencies:
+    "@babel/traverse" "^7.14.0"
+    "@sindresorhus/slugify" "^1.1.2"
+    chokidar "^3.5.1"
+    fs-exists-cached "^1.0.0"
+    gatsby-core-utils "^2.8.0"
+    gatsby-page-utils "^1.8.0"
+    gatsby-telemetry "^2.8.0"
     globby "^11.0.3"
     lodash "^4.17.21"
 
@@ -8673,6 +8744,26 @@ gatsby-telemetry@^2.4.0:
     configstore "^5.0.1"
     fs-extra "^8.1.0"
     gatsby-core-utils "^2.4.0"
+    git-up "^4.0.2"
+    is-docker "^2.1.1"
+    lodash "^4.17.21"
+    node-fetch "^2.6.1"
+    uuid "3.4.0"
+
+gatsby-telemetry@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-2.8.0.tgz#50b5ddc6b19ab43fbb71c8c317413a6c07ba89ef"
+  integrity sha512-MlV9Lbminhsz1MUiWJJvZ+8VVhIYBl2AsxJylckGoUp+skGfNq5d3pWSv+u/nU4zVP8T1HUWc1c7KSVq6ggrbw==
+  dependencies:
+    "@babel/code-frame" "^7.14.0"
+    "@babel/runtime" "^7.14.0"
+    "@turist/fetch" "^7.1.7"
+    "@turist/time" "^0.0.1"
+    async-retry-ng "^2.0.1"
+    boxen "^4.2.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^2.8.0"
     git-up "^4.0.2"
     is-docker "^2.1.1"
     lodash "^4.17.21"


### PR DESCRIPTION
If we use a context or try to calculate the page title ourselves, then it won't appear until hydration is complete, causing visible flickering and also not being available for analytics purposes (all <title>s that include a dynamic page title will initially just say "Arknights Tools").

We're using v1-style layout components because we want to preserve site-wide state while navigating between pages. Previously that was both menu open/close state and the Netlify Identity user, but right now it's just the menu. Anyway, because we aren't explicitly rendering `<Layout>` in each page, we can't pass props to it that are available at SSR time. So we have to instead pass pageTitle in the `pageContext` using `gatsby-node.js`.