### PR TITLE
Update operators.json to include skill and class data for all operators

### DIFF
--- a/scripts/globals.ts
+++ b/scripts/globals.ts
@@ -26,8 +26,7 @@ const operatorNameOverride: Record<string, string> = {
   Роса: "Rosa",
 };
 
-const itemNameOverride: Record<string, string> = {
-};
+const itemNameOverride: Record<string, string> = {};
 
 export function getOperatorName(operatorId: string): string | null {
   if (operatorId === "char_1001_amiya2") {
@@ -97,4 +96,27 @@ export function toIngredient({
     quantity: count,
     sortId: cnItemTable[id as keyof typeof cnItemTable].sortId,
   };
+}
+
+export function toTitleCase(string: string): string {
+  return [...string.toLowerCase()]
+    .map((char, i) => (i === 0 ? char.toUpperCase() : char))
+    .join("");
+}
+
+export function professionToClass(profession: string): string {
+  switch (profession) {
+    case "PIONEER":
+      return "Vanguard";
+    case "WARRIOR":
+      return "Guard";
+    case "SPECIAL":
+      return "Specialist";
+    case "TANK":
+      return "Defender";
+    case "SUPPORT":
+      return "Supporter";
+    default:
+      return toTitleCase(profession);
+  }
 }

--- a/scripts/operators.ts
+++ b/scripts/operators.ts
@@ -137,7 +137,6 @@ const operatorEntries = operatorIds.map((id: string) => {
     );
     // skill # -> { skill name, skill 1 masteries, skill 2 masteries, ... }
     return {
-      slot: i + 1,
       skillId: masteryLevelEntry.skillId,
       iconId:
         skillTable[masteryLevelEntry.skillId as keyof typeof skillTable].iconId,

--- a/scripts/operators.ts
+++ b/scripts/operators.ts
@@ -13,7 +13,9 @@ import {
   toIngredient,
   ARKNIGHTS_DATA_DIR,
   Ingredient,
+  professionToClass,
 } from "./globals";
+import { Operator } from "../src/types";
 
 enum GoalCategory {
   "Elite" = 0,
@@ -70,17 +72,24 @@ const operatorEntries = operatorIds.map((id: string) => {
     typeof enCharacterPatchTable[
       operatorId as keyof typeof enCharacterPatchTable
     ] === "undefined";
-  const entry: any = {
+
+  const entry = isPatchCharacter
+    ? cnCharacterPatchTable[operatorId as keyof typeof cnCharacterPatchTable]
+    : cnCharacterTable[operatorId as keyof typeof cnCharacterTable];
+  const operator: any = {
     id,
-    name,
+    name: name ?? "",
     isCnOnly,
+    rarity: entry.rarity + 1, // 0-indexed rarity
+    class: professionToClass(entry.profession),
+    skillLevels: [],
+    elite: [],
+    skills: [],
   };
-  if (name === "Amiya (Guard)") {
-    entry.rarity = 5;
-  }
+  // so far the only patch character is Guardmiya, and she has the exact same elite
+  // and skill level costs defined as Castermiya, so we don't want to duplicate those across both
   if (!isPatchCharacter) {
-    entry.rarity = cnCharacterTable[operatorId].rarity + 1;
-    entry.skillLevels = (cnCharacterTable[operatorId]
+    operator.skillLevels = (cnCharacterTable[operatorId]
       .allSkillLvlup as SkillLevelEntry[]).map((skillLevelEntry, i) => {
       const cost = skillLevelEntry.lvlUpCost;
       const ingredients = cost.map(toIngredient);
@@ -95,11 +104,11 @@ const operatorEntries = operatorIds.map((id: string) => {
       };
     });
     // operatorData[id].phases[0] is E0, so we skip that one
-    entry.elite = (cnCharacterTable[operatorId].phases.slice(
+    operator.elite = (cnCharacterTable[operatorId].phases.slice(
       1
     ) as EliteLevelEntry[]).map(({ evolveCost }, i) => {
       const ingredients = evolveCost.map(toIngredient);
-      ingredients.unshift(getEliteLMDCost(entry.rarity, i + 1));
+      ingredients.unshift(getEliteLMDCost(operator.rarity, i + 1));
       // [0] points to E1, [1] points to E2, so add 1
       return {
         eliteLevel: i + 1,
@@ -109,42 +118,36 @@ const operatorEntries = operatorIds.map((id: string) => {
       };
     });
   }
-  if (isPatchCharacter || entry.rarity > 3) {
-    const skillTable = isCnOnly ? cnSkillTable : enSkillTable;
-    const masteryEntries = (isPatchCharacter
-      ? cnCharacterPatchTable[operatorId as keyof typeof cnCharacterPatchTable]
-          .skills
-      : cnCharacterTable[operatorId].skills) as MasteryLevelEntry[];
-    entry.skills = masteryEntries.map((masteryLevelEntry, i) => {
-      // masteryLevelEntry contains data on all 3 mastery levels for one skill
-      const masteries: OperatorGoal[] = masteryLevelEntry.levelUpCostCond.map(
-        ({ levelUpCost }, j) => {
-          const ingredients = levelUpCost.map(toIngredient);
-          // mastery level -> array of ingredients
-          return {
-            masteryLevel: j + 1,
-            ingredients,
-            goalName: `Skill ${i + 1} Mastery ${j + 1}`,
-            goalShortName: `S${i + 1} M${j + 1}`,
-            goalCategory: GoalCategory.Mastery,
-          };
-        }
-      );
-      // skill # -> { skill name, skill 1 masteries, skill 2 masteries, ... }
-      return {
-        slot: i + 1,
-        skillId: masteryLevelEntry.skillId,
-        iconId:
-          skillTable[masteryLevelEntry.skillId as keyof typeof skillTable]
-            .iconId,
-        skillName:
-          skillTable[masteryLevelEntry.skillId as keyof typeof skillTable]
-            .levels[0].name,
-        masteries,
-      };
-    });
-  }
-  return entry;
+  const skillTable = isCnOnly ? cnSkillTable : enSkillTable;
+  const masteryEntries = entry.skills as MasteryLevelEntry[];
+  operator.skills = masteryEntries.map((masteryLevelEntry, i) => {
+    // masteryLevelEntry contains data on all 3 mastery levels for one skill
+    const masteries: OperatorGoal[] = masteryLevelEntry.levelUpCostCond.map(
+      ({ levelUpCost }, j) => {
+        const ingredients = levelUpCost.map(toIngredient);
+        // mastery level -> array of ingredients
+        return {
+          masteryLevel: j + 1,
+          ingredients,
+          goalName: `Skill ${i + 1} Mastery ${j + 1}`,
+          goalShortName: `S${i + 1} M${j + 1}`,
+          goalCategory: GoalCategory.Mastery,
+        };
+      }
+    );
+    // skill # -> { skill name, skill 1 masteries, skill 2 masteries, ... }
+    return {
+      slot: i + 1,
+      skillId: masteryLevelEntry.skillId,
+      iconId:
+        skillTable[masteryLevelEntry.skillId as keyof typeof skillTable].iconId,
+      skillName:
+        skillTable[masteryLevelEntry.skillId as keyof typeof skillTable]
+          .levels[0].name,
+      masteries,
+    };
+  });
+  return operator;
 });
 
 fs.mkdirSync(ARKNIGHTS_DATA_DIR, { recursive: true });

--- a/scripts/recruitment.ts
+++ b/scripts/recruitment.ts
@@ -1,8 +1,7 @@
-import { Typography } from "@material-ui/core";
 import fs from "fs";
 import path from "path";
 import { Combination } from "js-combinatorics";
-import { ARKNIGHTS_DATA_DIR } from "./globals";
+import { ARKNIGHTS_DATA_DIR, professionToClass, toTitleCase } from "./globals";
 import { recruitDetail } from "./ArknightsGameData/en_US/gamedata/excel/gacha_table.json";
 import characterTable from "./ArknightsGameData/en_US/gamedata/excel/character_table.json";
 
@@ -40,29 +39,6 @@ const RECRUITMENT_TAGS = [
   "Support",
   "Survival",
 ];
-
-function toTitleCase(string: string) {
-  return [...string.toLowerCase()]
-    .map((char, i) => (i === 0 ? char.toUpperCase() : char))
-    .join("");
-}
-
-function professionToClass(profession: string) {
-  switch (profession) {
-    case "PIONEER":
-      return "Vanguard";
-    case "WARRIOR":
-      return "Guard";
-    case "SPECIAL":
-      return "Specialist";
-    case "TANK":
-      return "Defender";
-    case "SUPPORT":
-      return "Supporter";
-    default:
-      return toTitleCase(profession);
-  }
-}
 
 const operatorNameToId: Record<
   string,

--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -213,7 +213,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_magic_rage[3]",
         "iconId": null,
         "skillName": "Tactical Chant γ",
@@ -308,7 +307,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_amiya_2",
         "iconId": null,
         "skillName": "Spirit Burst",
@@ -403,7 +401,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_amiya_3",
         "iconId": null,
         "skillName": "Chimera",
@@ -727,7 +724,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_kalts_1",
         "iconId": null,
         "skillName": "指令：结构加固",
@@ -822,7 +818,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_kalts_2",
         "iconId": null,
         "skillName": "指令：战术协同",
@@ -917,7 +912,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_kalts_3",
         "iconId": null,
         "skillName": "指令：熔毁",
@@ -1251,7 +1245,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_chen_1",
         "iconId": null,
         "skillName": "Sheathed Strike",
@@ -1346,7 +1339,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_chen_2",
         "iconId": null,
         "skillName": "Chi Xiao - Unsheath",
@@ -1441,7 +1433,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_chen_3",
         "iconId": null,
         "skillName": "Chi Xiao - Shadowless",
@@ -1765,7 +1756,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_huang_1",
         "iconId": "skcom_powerstrike[3]",
         "skillName": "Power Strike γ",
@@ -1860,7 +1850,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_huang_2",
         "iconId": null,
         "skillName": "Chainsaw Extension Module",
@@ -1955,7 +1944,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_huang_3",
         "iconId": null,
         "skillName": "Boiling Burst",
@@ -2265,7 +2253,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_sora_1",
         "iconId": null,
         "skillName": "Hymn of Respite",
@@ -2360,7 +2347,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sora_2",
         "iconId": null,
         "skillName": "Hymn of Battle",
@@ -2670,7 +2656,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_lava2_1",
         "iconId": null,
         "skillName": "焰淬匕首",
@@ -2765,7 +2750,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_lava2_2",
         "iconId": null,
         "skillName": "狱火之环",
@@ -3089,7 +3073,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_skadi2_1",
         "iconId": null,
         "skillName": "同归殊途之吟",
@@ -3184,7 +3167,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_skadi2_2",
         "iconId": null,
         "skillName": "同葬无光之愿",
@@ -3279,7 +3261,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_skadi2_3",
         "iconId": null,
         "skillName": "\"潮涌，潮枯\"",
@@ -3589,7 +3570,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[3]",
         "iconId": null,
         "skillName": "Charge γ",
@@ -3684,7 +3664,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_texas_2",
         "iconId": null,
         "skillName": "Sword Rain",
@@ -4008,7 +3987,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_angel_1",
         "iconId": null,
         "skillName": "Charging Mode",
@@ -4103,7 +4081,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_angel_2",
         "iconId": null,
         "skillName": "Shooting Mode",
@@ -4198,7 +4175,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_angel_3",
         "iconId": null,
         "skillName": "Overloading Mode",
@@ -4508,7 +4484,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[3]",
         "iconId": null,
         "skillName": "Swift Strike γ",
@@ -4603,7 +4578,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_franka_2",
         "iconId": null,
         "skillName": "Vorpal Edge",
@@ -4913,7 +4887,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_liskam_1",
         "iconId": null,
         "skillName": "Charged Defense",
@@ -5008,7 +4981,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_liskam_2",
         "iconId": null,
         "skillName": "Counter Arc",
@@ -5318,7 +5290,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[3]",
         "iconId": null,
         "skillName": "Healing Up γ",
@@ -5413,7 +5384,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_silent_2",
         "iconId": null,
         "skillName": "Medical Drone",
@@ -5716,7 +5686,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_magic_rage[2]",
         "iconId": null,
         "skillName": "Tactical Chant β",
@@ -5811,7 +5780,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_fmout_2",
         "iconId": null,
         "skillName": "Destiny",
@@ -6114,7 +6082,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_deepcl_1",
         "iconId": null,
         "skillName": "Shadow Tentacle",
@@ -6209,7 +6176,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_deepcl_2",
         "iconId": null,
         "skillName": "Visual Trap",
@@ -6533,7 +6499,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[3]",
         "iconId": null,
         "skillName": "Charge γ",
@@ -6628,7 +6593,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_siege_2",
         "iconId": null,
         "skillName": "Aerial Hammer",
@@ -6723,7 +6687,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_siege_3",
         "iconId": null,
         "skillName": "Skull Breaker",
@@ -7047,7 +7010,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_cqbw_1",
         "iconId": null,
         "skillName": "King of Hearts",
@@ -7142,7 +7104,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cqbw_2",
         "iconId": null,
         "skillName": "Jack in the Box",
@@ -7237,7 +7198,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_cqbw_3",
         "iconId": null,
         "skillName": "D12",
@@ -7547,7 +7507,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[3]",
         "iconId": null,
         "skillName": "Charge γ",
@@ -7642,7 +7601,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_headbr_2",
         "iconId": null,
         "skillName": "Ursus's Roar",
@@ -7945,7 +7903,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_myrrh_1",
         "iconId": null,
         "skillName": "Dual Healing",
@@ -8040,7 +7997,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_myrrh_2",
         "iconId": null,
         "skillName": "Medic Field",
@@ -8343,7 +8299,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_yuki_1",
         "iconId": null,
         "skillName": "Shuriken",
@@ -8438,7 +8393,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_yuki_2",
         "iconId": null,
         "skillName": "Fatal Shuriken",
@@ -8685,7 +8639,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[1]",
         "iconId": null,
         "skillName": "Healing Up α",
@@ -8844,7 +8797,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_magic_rage[1]",
         "iconId": null,
         "skillName": "Tactical Chant α",
@@ -9003,7 +8955,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[1]",
         "iconId": null,
         "skillName": "DEF Up α",
@@ -9162,7 +9113,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[1]",
         "iconId": null,
         "skillName": "Charge α",
@@ -9321,7 +9271,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_kroos_1",
         "iconId": null,
         "skillName": "Double Tap - Auto",
@@ -9536,7 +9485,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_shotst_1",
         "iconId": null,
         "skillName": "Armor Breaker",
@@ -9631,7 +9579,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_shotst_2",
         "iconId": null,
         "skillName": "Armor Breaker - Spread",
@@ -9934,7 +9881,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -10029,7 +9975,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_estell_2",
         "iconId": null,
         "skillName": "Sacrificial Strike",
@@ -10339,7 +10284,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[3]",
         "iconId": null,
         "skillName": "Healing Up γ",
@@ -10434,7 +10378,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_plosis_2",
         "iconId": null,
         "skillName": "Enkephalin",
@@ -10744,7 +10687,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_bluep_1",
         "iconId": null,
         "skillName": "Twinshot - Auto",
@@ -10839,7 +10781,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bluep_2",
         "iconId": null,
         "skillName": "Venom Spray",
@@ -11142,7 +11083,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_doberm_1",
         "iconId": "skcom_powerstrike[2]",
         "skillName": "Power Strike β",
@@ -11237,7 +11177,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_doberm_2",
         "iconId": null,
         "skillName": "Spur",
@@ -11547,7 +11486,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_flameb_1",
         "iconId": null,
         "skillName": "Blood Pact",
@@ -11642,7 +11580,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_flameb_2",
         "iconId": null,
         "skillName": "Blade Demon",
@@ -11945,7 +11882,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_mm_1",
         "iconId": null,
         "skillName": "Paralyzing Shell",
@@ -12040,7 +11976,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mm_2",
         "iconId": null,
         "skillName": "Binding Shock",
@@ -12364,7 +12299,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ifrit_1",
         "iconId": null,
         "skillName": "Fanaticism",
@@ -12459,7 +12393,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ifrit_2",
         "iconId": null,
         "skillName": "Pyroclasm",
@@ -12554,7 +12487,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_ifrit_3",
         "iconId": null,
         "skillName": "Scorched Earth",
@@ -12878,7 +12810,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_hsguma_1",
         "iconId": null,
         "skillName": "Warpath",
@@ -12973,7 +12904,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_hsguma_2",
         "iconId": null,
         "skillName": "Thorns",
@@ -13068,7 +12998,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_hsguma_3",
         "iconId": null,
         "skillName": "Saw of Strength",
@@ -13371,7 +13300,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_brownb_1",
         "iconId": null,
         "skillName": "Flexibility",
@@ -13466,7 +13394,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_brownb_2",
         "iconId": null,
         "skillName": "Soaring Fists",
@@ -13776,7 +13703,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_whitew_1",
         "iconId": null,
         "skillName": "Sundial",
@@ -13871,7 +13797,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_whitew_2",
         "iconId": null,
         "skillName": "Wolf Spirit",
@@ -14174,7 +14099,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -14269,7 +14193,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_nights_2",
         "iconId": null,
         "skillName": "Crimson Eyes",
@@ -14579,7 +14502,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -14674,7 +14596,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ghost_2",
         "iconId": null,
         "skillName": "Bone Fracture",
@@ -14984,7 +14905,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_red_1",
         "iconId": null,
         "skillName": "Execution Mode",
@@ -15079,7 +14999,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_red_2",
         "iconId": null,
         "skillName": "Wolfpack",
@@ -15389,7 +15308,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_prove_1",
         "iconId": null,
         "skillName": "Wolf's Eye",
@@ -15484,7 +15402,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_prove_2",
         "iconId": null,
         "skillName": "Prey Seeker",
@@ -15808,7 +15725,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_shining_1",
         "iconId": null,
         "skillName": "Creed",
@@ -15903,7 +15819,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_shining_2",
         "iconId": null,
         "skillName": "Auto Protect",
@@ -15998,7 +15913,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_shining_3",
         "iconId": null,
         "skillName": "Creed Field",
@@ -16308,7 +16222,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_nearl_1",
         "iconId": null,
         "skillName": "First Aid",
@@ -16403,7 +16316,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_nearl_2",
         "iconId": null,
         "skillName": "First Aid Mode",
@@ -16706,7 +16618,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[2]",
         "iconId": null,
         "skillName": "Charge β",
@@ -16801,7 +16712,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_scave_2",
         "iconId": null,
         "skillName": "Command - Attack",
@@ -17104,7 +17014,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[2]",
         "iconId": null,
         "skillName": "DEF Up β",
@@ -17199,7 +17108,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_snakek_2",
         "iconId": null,
         "skillName": "Shell Defense",
@@ -17502,7 +17410,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_assist_cost[2]",
         "iconId": null,
         "skillName": "Support β",
@@ -17597,7 +17504,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_myrtle_2",
         "iconId": null,
         "skillName": "Healing Wings",
@@ -17907,7 +17813,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_tiger_1",
         "iconId": null,
         "skillName": "Armorcrusher",
@@ -18002,7 +17907,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_tiger_2",
         "iconId": null,
         "skillName": "Sundered Soul",
@@ -18312,7 +18216,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_milu_1",
         "iconId": null,
         "skillName": "Camouflage",
@@ -18407,7 +18310,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_milu_2",
         "iconId": null,
         "skillName": "Tactical Transceiver",
@@ -18710,7 +18612,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_peacok_1",
         "iconId": null,
         "skillName": "Judgment",
@@ -18805,7 +18706,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_peacok_2",
         "iconId": null,
         "skillName": "Genesis",
@@ -19115,7 +19015,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_hpsts_1",
         "iconId": null,
         "skillName": "Guardian Mode",
@@ -19210,7 +19109,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_hpsts_2",
         "iconId": null,
         "skillName": "Combat Mode",
@@ -19520,7 +19418,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_nightm_1",
         "iconId": null,
         "skillName": "Drain Soul",
@@ -19615,7 +19512,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_nightm_2",
         "iconId": null,
         "skillName": "Night Phantom",
@@ -19925,7 +19821,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -20020,7 +19915,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_skfire_2",
         "iconId": null,
         "skillName": "Fire of Heaven",
@@ -20330,7 +20224,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_bldsk_1",
         "iconId": null,
         "skillName": "Emergency Triage",
@@ -20425,7 +20318,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bldsk_2",
         "iconId": null,
         "skillName": "Unstable Plasma",
@@ -20749,7 +20641,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_svrash_1",
         "iconId": "skcom_powerstrike[3]",
         "skillName": "Power Strike γ",
@@ -20844,7 +20735,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_svrash_2",
         "iconId": null,
         "skillName": "Rules of Survival",
@@ -20939,7 +20829,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_svrash_3",
         "iconId": null,
         "skillName": "Truesilver Slash",
@@ -21249,7 +21138,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_slchan_1",
         "iconId": null,
         "skillName": "Chain Hook",
@@ -21344,7 +21232,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_slchan_2",
         "iconId": null,
         "skillName": "Binding Chains",
@@ -21654,7 +21541,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_slbell_1",
         "iconId": null,
         "skillName": "Echolocation",
@@ -21749,7 +21635,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_slbell_2",
         "iconId": null,
         "skillName": "Natural Deterrent",
@@ -22073,7 +21958,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[3]",
         "iconId": null,
         "skillName": "Healing Up γ",
@@ -22168,7 +22052,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cgbird_2",
         "iconId": null,
         "skillName": "Arts Shield",
@@ -22263,7 +22146,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_cgbird_3",
         "iconId": null,
         "skillName": "Sanctuary",
@@ -22587,7 +22469,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_amgoat_1",
         "iconId": null,
         "skillName": "Duetto",
@@ -22682,7 +22563,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_amgoat_2",
         "iconId": null,
         "skillName": "Ignition",
@@ -22777,7 +22657,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_amgoat_3",
         "iconId": null,
         "skillName": "Volcano",
@@ -23080,7 +22959,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[2]",
         "iconId": null,
         "skillName": "Healing Up β",
@@ -23175,7 +23053,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_flower_2",
         "iconId": null,
         "skillName": "Fine Blending",
@@ -23478,7 +23355,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -23573,7 +23449,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_skgoat_2",
         "iconId": null,
         "skillName": "Quicksand Conversion",
@@ -23876,7 +23751,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_frncat_1",
         "iconId": null,
         "skillName": "Scratch",
@@ -23971,7 +23845,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_frncat_2",
         "iconId": null,
         "skillName": "Fury",
@@ -24274,7 +24147,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ccheal_1",
         "iconId": null,
         "skillName": "Vitality Restoration",
@@ -24369,7 +24241,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ccheal_2",
         "iconId": null,
         "skillName": "Vitality Restoration - Wide Range",
@@ -24693,7 +24564,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_helage_1",
         "iconId": null,
         "skillName": "Crescent Moon",
@@ -24788,7 +24658,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_helage_2",
         "iconId": null,
         "skillName": "Half Moon",
@@ -24883,7 +24752,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_helage_3",
         "iconId": null,
         "skillName": "Full Moon",
@@ -25186,7 +25054,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -25281,7 +25148,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_clour_2",
         "iconId": null,
         "skillName": "Double Shot",
@@ -25528,7 +25394,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[1]",
         "iconId": null,
         "skillName": "Swift Strike α",
@@ -25743,7 +25608,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_frostl_1",
         "iconId": null,
         "skillName": "Frost Tomahawk",
@@ -25838,7 +25702,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_frostl_2",
         "iconId": null,
         "skillName": "Ice Tomahawk",
@@ -26148,7 +26011,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_glassb_1",
         "iconId": null,
         "skillName": "Concentration",
@@ -26243,7 +26105,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_glassb_2",
         "iconId": null,
         "skillName": "Literature Storm",
@@ -26546,7 +26407,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_sunbr_1",
         "iconId": null,
         "skillName": "Provisions",
@@ -26641,7 +26501,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sunbr_2",
         "iconId": null,
         "skillName": "Cooking",
@@ -26965,7 +26824,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -27060,7 +26918,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_poca_2",
         "iconId": null,
         "skillName": "Split Shot",
@@ -27155,7 +27012,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_poca_3",
         "iconId": null,
         "skillName": "Avalanche Breaker",
@@ -27458,7 +27314,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[2]",
         "iconId": null,
         "skillName": "Charge β",
@@ -27553,7 +27408,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_blackd_2",
         "iconId": null,
         "skillName": "Command - Defense",
@@ -27856,7 +27710,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_yak_1",
         "iconId": null,
         "skillName": "Stamina Enhancement",
@@ -27951,7 +27804,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_yak_2",
         "iconId": null,
         "skillName": "Cold Resistance",
@@ -28261,7 +28113,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_moeshd_1",
         "iconId": null,
         "skillName": "Auto Defense",
@@ -28356,7 +28207,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_moeshd_2",
         "iconId": null,
         "skillName": "Magnetic Hammer",
@@ -28680,7 +28530,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_cerber_1",
         "iconId": null,
         "skillName": "\"Really Cold Axe\"",
@@ -28775,7 +28624,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cerber_2",
         "iconId": null,
         "skillName": "\"Really Hot Knives\"",
@@ -28870,7 +28718,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_cerber_3",
         "iconId": null,
         "skillName": "\"Really Heavy Spear\"",
@@ -29194,7 +29041,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_nian_1",
         "iconId": null,
         "skillName": "Tin Burning",
@@ -29289,7 +29135,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_nian_2",
         "iconId": null,
         "skillName": "Copper Seal",
@@ -29384,7 +29229,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_nian_3",
         "iconId": null,
         "skillName": "Iron Defense",
@@ -29708,7 +29552,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_dusk_1",
         "iconId": null,
         "skillName": "工笔入化",
@@ -29803,7 +29646,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_dusk_2",
         "iconId": null,
         "skillName": "泼墨淋漓",
@@ -29898,7 +29740,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_dusk_3",
         "iconId": null,
         "skillName": "写意胜形",
@@ -30222,7 +30063,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_demkni_1",
         "iconId": null,
         "skillName": "First Aid",
@@ -30317,7 +30157,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_demkni_2",
         "iconId": null,
         "skillName": "Medicine Dispensing",
@@ -30412,7 +30251,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_demkni_3",
         "iconId": null,
         "skillName": "Calcification",
@@ -30722,7 +30560,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -30817,7 +30654,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_platnm_2",
         "iconId": null,
         "skillName": "Pegasian Sight",
@@ -31064,7 +30900,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[1]",
         "iconId": null,
         "skillName": "ATK Up α",
@@ -31223,7 +31058,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_self[1]",
         "iconId": null,
         "skillName": "Regeneration α",
@@ -31382,7 +31216,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_stward_1",
         "iconId": "skcom_powerstrike[1]",
         "skillName": "Power Strike α",
@@ -31541,7 +31374,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[1]",
         "iconId": null,
         "skillName": "ATK Up α",
@@ -31700,7 +31532,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_range_extend",
         "iconId": null,
         "skillName": "Healing Range Up",
@@ -31936,7 +31767,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -32031,7 +31861,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mostma_2",
         "iconId": null,
         "skillName": "Lock of Shattered Time",
@@ -32126,7 +31955,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_mostma_3",
         "iconId": null,
         "skillName": "Key of Chronology",
@@ -32436,7 +32264,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_kafka_1",
         "iconId": null,
         "skillName": "Cube of Absurdism",
@@ -32531,7 +32358,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_kafka_2",
         "iconId": null,
         "skillName": "Shears of Surrealism",
@@ -32841,7 +32667,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_mantic_1",
         "iconId": null,
         "skillName": "Scorpion Venom",
@@ -32936,7 +32761,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mantic_2",
         "iconId": null,
         "skillName": "Toxic Overload",
@@ -33246,7 +33070,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -33341,7 +33164,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cuttle_2",
         "iconId": null,
         "skillName": "Interdictive Sniping Tactics",
@@ -33651,7 +33473,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_meteo_1",
         "iconId": null,
         "skillName": "Buckshot",
@@ -33746,7 +33567,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_meteo_2",
         "iconId": null,
         "skillName": "High-Explosive Shell",
@@ -34056,7 +33876,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[3]",
         "iconId": null,
         "skillName": "DEF Up γ",
@@ -34151,7 +33970,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_grani_2",
         "iconId": null,
         "skillName": "Press the Attack!",
@@ -34475,7 +34293,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[3]",
         "iconId": null,
         "skillName": "Swift Strike γ",
@@ -34570,7 +34387,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bpipe_2",
         "iconId": null,
         "skillName": "High-Impact Assault",
@@ -34665,7 +34481,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_bpipe_3",
         "iconId": null,
         "skillName": "Locked Breech Burst",
@@ -34989,7 +34804,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_haak_1",
         "iconId": null,
         "skillName": "Rapid Fire",
@@ -35084,7 +34898,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_haak_2",
         "iconId": null,
         "skillName": "Type-γ Stimpack",
@@ -35179,7 +34992,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_haak_3",
         "iconId": null,
         "skillName": "Durian-Flavored Stimpack",
@@ -35489,7 +35301,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_hmau_1",
         "iconId": null,
         "skillName": "Treatment Countermeasure",
@@ -35584,7 +35395,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_hmau_2",
         "iconId": null,
         "skillName": "Medical Mode Countermeasure",
@@ -35894,7 +35704,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_savage_1",
         "iconId": "skcom_powerstrike[2]",
         "skillName": "Power Strike β",
@@ -35989,7 +35798,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_savage_2",
         "iconId": null,
         "skillName": "Precise Blast",
@@ -36292,7 +36100,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_jesica_1",
         "iconId": "skcom_powerstrike[2]",
         "skillName": "Power Strike β",
@@ -36387,7 +36194,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_jesica_2",
         "iconId": null,
         "skillName": "Smokescreen",
@@ -36690,7 +36496,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_rope_1",
         "iconId": null,
         "skillName": "Hook Shot",
@@ -36785,7 +36590,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_rope_2",
         "iconId": null,
         "skillName": "Double Hook",
@@ -37088,7 +36892,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_gravel_1",
         "iconId": null,
         "skillName": "Shadow Assault",
@@ -37183,7 +36986,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_gravel_2",
         "iconId": null,
         "skillName": "Rat Swarm",
@@ -37430,7 +37232,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_wyvern_1",
         "iconId": null,
         "skillName": "Command - Reinforcement",
@@ -37652,7 +37453,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_panda_1",
         "iconId": null,
         "skillName": "Raging Iron Fist",
@@ -37747,7 +37547,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_panda_2",
         "iconId": null,
         "skillName": "Destructive Fist",
@@ -38057,7 +37856,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_otter_1",
         "iconId": null,
         "skillName": "Bionic Device",
@@ -38152,7 +37950,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_otter_2",
         "iconId": null,
         "skillName": "Detonate and Recycle",
@@ -38462,7 +38259,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_waaifu_1",
         "iconId": null,
         "skillName": "One-inch Punch",
@@ -38557,7 +38353,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_waaifu_2",
         "iconId": null,
         "skillName": "Seven-styles Kick",
@@ -38881,7 +38676,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_mgllan_1",
         "iconId": null,
         "skillName": "High-Efficiency Freezing Module",
@@ -38976,7 +38770,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mgllan_2",
         "iconId": null,
         "skillName": "Laser Mining Module",
@@ -39071,7 +38864,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_mgllan_3",
         "iconId": null,
         "skillName": "Armed Combat Module",
@@ -39395,7 +39187,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_phatom_1",
         "iconId": null,
         "skillName": "Phantom of the Night",
@@ -39490,7 +39281,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_phatom_2",
         "iconId": null,
         "skillName": "Bloody Opus",
@@ -39585,7 +39375,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_phatom_3",
         "iconId": null,
         "skillName": "Night Raid",
@@ -39895,7 +39684,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_bibeak_1",
         "iconId": null,
         "skillName": "Plumage Pins",
@@ -39990,7 +39778,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bibeak_2",
         "iconId": null,
         "skillName": "Blade Swap",
@@ -40293,7 +40080,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_magic_rage[2]",
         "iconId": null,
         "skillName": "Tactical Chant β",
@@ -40388,7 +40174,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_greyy_2",
         "iconId": null,
         "skillName": "Electrostatic Discharge",
@@ -40698,7 +40483,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_vodfox_1",
         "iconId": null,
         "skillName": "Malediction",
@@ -40793,7 +40577,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_vodfox_2",
         "iconId": null,
         "skillName": "Cursed Doll",
@@ -41096,7 +40879,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_podego_1",
         "iconId": null,
         "skillName": "Aromatherapy",
@@ -41191,7 +40973,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_podego_2",
         "iconId": null,
         "skillName": "Spread Spores",
@@ -41494,7 +41275,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -41589,7 +41369,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_durnar_2",
         "iconId": null,
         "skillName": "Shielded Counterattack",
@@ -41899,7 +41678,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[3]",
         "iconId": null,
         "skillName": "Swift Strike γ",
@@ -41994,7 +41772,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sddrag_2",
         "iconId": null,
         "skillName": "Soul Spark",
@@ -42318,7 +42095,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[3]",
         "iconId": null,
         "skillName": "Swift Strike γ",
@@ -42413,7 +42189,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_skadi_2",
         "iconId": null,
         "skillName": "Wave Strike",
@@ -42508,7 +42283,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_skadi_3",
         "iconId": null,
         "skillName": "Tidal Elegy",
@@ -42832,7 +42606,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_f12yin_1",
         "iconId": null,
         "skillName": "Left Hook",
@@ -42927,7 +42700,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_f12yin_2",
         "iconId": null,
         "skillName": "Sweeping Stance",
@@ -43022,7 +42794,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_f12yin_3",
         "iconId": null,
         "skillName": "Earth-Shattering Smash",
@@ -43332,7 +43103,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_sophia_1",
         "iconId": null,
         "skillName": "Motivational Skills",
@@ -43427,7 +43197,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sophia_2",
         "iconId": null,
         "skillName": "Whip Sword",
@@ -43730,7 +43499,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_spikes_1",
         "iconId": null,
         "skillName": "Just Kidding",
@@ -43825,7 +43593,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_spikes_2",
         "iconId": null,
         "skillName": "Deadly Prank",
@@ -44128,7 +43895,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_strong_1",
         "iconId": null,
         "skillName": "Shell Splitter",
@@ -44223,7 +43989,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_strong_2",
         "iconId": null,
         "skillName": "Sashimi Platter",
@@ -44533,7 +44298,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_astesi_1",
         "iconId": null,
         "skillName": "Astral Protection",
@@ -44628,7 +44392,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_astesi_2",
         "iconId": null,
         "skillName": "Astral Sword",
@@ -44938,7 +44701,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_breeze_1",
         "iconId": null,
         "skillName": "Cluster Therapy",
@@ -45033,7 +44795,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_breeze_2",
         "iconId": null,
         "skillName": "Widespread Therapy",
@@ -45336,7 +45097,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_sqrrel_1",
         "iconId": null,
         "skillName": "Steam Pump",
@@ -45431,7 +45191,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sqrrel_2",
         "iconId": null,
         "skillName": "High-Pressure Water Cannon",
@@ -45678,7 +45437,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[1]",
         "iconId": null,
         "skillName": "Swift Strike α",
@@ -45900,7 +45658,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_excu_1",
         "iconId": null,
         "skillName": "Muzzle’s Elegy",
@@ -45995,7 +45752,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_excu_2",
         "iconId": null,
         "skillName": "Final Journey",
@@ -46242,7 +45998,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[1]",
         "iconId": null,
         "skillName": "ATK Up α",
@@ -46401,7 +46156,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_catap_1",
         "iconId": "skcom_blowrange_up[1]",
         "skillName": "Blast Range Up α",
@@ -46560,7 +46314,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_midn_1",
         "iconId": "skcom_enchant[1]",
         "skillName": "Enchant Weapon α",
@@ -46719,7 +46472,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_spot_1",
         "iconId": null,
         "skillName": "Secondary Healing Mode",
@@ -46954,7 +46706,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_self[2]",
         "iconId": null,
         "skillName": "Regeneration β",
@@ -47049,7 +46800,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_gyuki_2",
         "iconId": null,
         "skillName": "Demonic Power",
@@ -47352,7 +47102,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_vigna_1",
         "iconId": "skcom_atk_up[2]",
         "skillName": "ATK Up β",
@@ -47447,7 +47196,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_vigna_2",
         "iconId": null,
         "skillName": "Hammer-On",
@@ -47771,7 +47519,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_aglina_1",
         "iconId": null,
         "skillName": "Arcane Staff - Quick Charge Mode",
@@ -47866,7 +47613,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_aglina_2",
         "iconId": null,
         "skillName": "Arcane Staff - Particle Mode",
@@ -47961,7 +47707,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_aglina_3",
         "iconId": null,
         "skillName": "Arcane Staff - Anti-Gravity Mode",
@@ -48285,7 +48030,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -48380,7 +48124,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_thorns_2",
         "iconId": null,
         "skillName": "Protective Spikes",
@@ -48475,7 +48218,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_thorns_3",
         "iconId": null,
         "skillName": "Destreza",
@@ -48785,7 +48527,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ayer_1",
         "iconId": null,
         "skillName": "Shrapnel Burst",
@@ -48880,7 +48621,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ayer_2",
         "iconId": null,
         "skillName": "Activate Phase Blades",
@@ -49183,7 +48923,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_up[2]",
         "iconId": null,
         "skillName": "Healing Up β",
@@ -49278,7 +49017,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_susuro_2",
         "iconId": null,
         "skillName": "Deep Healing",
@@ -49581,7 +49319,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_cutter_1",
         "iconId": null,
         "skillName": "Redshift",
@@ -49676,7 +49413,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cutter_2",
         "iconId": null,
         "skillName": "Crimson Crescent",
@@ -49979,7 +49715,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_glaze_1",
         "iconId": null,
         "skillName": "Snaring Shell",
@@ -50074,7 +49809,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_glaze_2",
         "iconId": null,
         "skillName": "Radar Sweep",
@@ -50384,7 +50118,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_zebra_1",
         "iconId": null,
         "skillName": "应急迷彩",
@@ -50479,7 +50212,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_zebra_2",
         "iconId": null,
         "skillName": "群体迷彩",
@@ -50789,7 +50521,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -50884,7 +50615,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_leizi_2",
         "iconId": null,
         "skillName": "Thunderclap",
@@ -51194,7 +50924,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_swire_1",
         "iconId": null,
         "skillName": "Command and Dispatch",
@@ -51289,7 +51018,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_swire_2",
         "iconId": null,
         "skillName": "Cooperative Combat",
@@ -51613,7 +51341,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[3]",
         "iconId": null,
         "skillName": "DEF Up γ",
@@ -51708,7 +51435,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mudrok_2",
         "iconId": null,
         "skillName": "Crag Splitter",
@@ -51803,7 +51529,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_mudrok_3",
         "iconId": null,
         "skillName": "Bloodline of Desecrated Earth",
@@ -52113,7 +51838,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[3]",
         "iconId": null,
         "skillName": "DEF Up γ",
@@ -52208,7 +51932,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bison_2",
         "iconId": null,
         "skillName": "Intensified Defense",
@@ -52518,7 +52241,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_glacus_1",
         "iconId": null,
         "skillName": "Binary Reload",
@@ -52613,7 +52335,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_glacus_2",
         "iconId": null,
         "skillName": "Counter EMP",
@@ -52916,7 +52637,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[2]",
         "iconId": null,
         "skillName": "ATK Up β",
@@ -53011,7 +52731,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_cammou_2",
         "iconId": null,
         "skillName": "Synchronized Attack",
@@ -53335,7 +53054,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_archet_1",
         "iconId": null,
         "skillName": "箭矢·散逸",
@@ -53430,7 +53148,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_archet_2",
         "iconId": null,
         "skillName": "箭矢·追猎",
@@ -53525,7 +53242,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_archet_3",
         "iconId": null,
         "skillName": "箭矢·暴风",
@@ -53835,7 +53551,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_heal_self[3]",
         "iconId": null,
         "skillName": "Regeneration γ",
@@ -53930,7 +53645,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sidero_2",
         "iconId": null,
         "skillName": "Restorative Surge",
@@ -54240,7 +53954,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_folivo_1",
         "iconId": null,
         "skillName": "Protective Camouflage",
@@ -54335,7 +54048,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_folivo_2",
         "iconId": null,
         "skillName": "Panoramic Overload",
@@ -54638,7 +54350,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_utage_1",
         "iconId": null,
         "skillName": "Space Out",
@@ -54733,7 +54444,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_utage_2",
         "iconId": null,
         "skillName": "Descending Strike - Earth Splitter",
@@ -55043,7 +54753,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_iris_1",
         "iconId": null,
         "skillName": "童话守卫者",
@@ -55138,7 +54847,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_iris_2",
         "iconId": null,
         "skillName": "梦乡摇篮",
@@ -55462,7 +55170,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_shwaz_1",
         "iconId": null,
         "skillName": "Charged Shot",
@@ -55557,7 +55264,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_shwaz_2",
         "iconId": null,
         "skillName": "Sharp Eye",
@@ -55652,7 +55358,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_shwaz_3",
         "iconId": null,
         "skillName": "Final Tactics",
@@ -55962,7 +55667,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_tknogi_1",
         "iconId": null,
         "skillName": "Without a Trace",
@@ -56057,7 +55761,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_tknogi_2",
         "iconId": null,
         "skillName": "Forest's Embrace",
@@ -56367,7 +56070,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_beewax_1",
         "iconId": null,
         "skillName": "Growing Sandstorm",
@@ -56462,7 +56164,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_beewax_2",
         "iconId": null,
         "skillName": "Guardian Obelisk",
@@ -56772,7 +56473,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_folnic_1",
         "iconId": null,
         "skillName": "Max-Dosage Infusion",
@@ -56867,7 +56567,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_folnic_2",
         "iconId": null,
         "skillName": "Compound Drug Shell",
@@ -57177,7 +56876,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_quickattack[3]",
         "iconId": null,
         "skillName": "Swift Strike γ",
@@ -57272,7 +56970,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_aosta_2",
         "iconId": null,
         "skillName": "Shadow Nails",
@@ -57575,7 +57272,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_jaksel_1",
         "iconId": null,
         "skillName": "Grit Those Teeth!",
@@ -57670,7 +57366,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_jaksel_2",
         "iconId": null,
         "skillName": "Pay Close Attention!",
@@ -57980,7 +57675,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ceylon_1",
         "iconId": null,
         "skillName": "Concentrated Hydrotherapy",
@@ -58075,7 +57769,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ceylon_2",
         "iconId": null,
         "skillName": "Water Blessing",
@@ -58385,7 +58078,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[3]",
         "iconId": null,
         "skillName": "Charge γ",
@@ -58480,7 +58172,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_chiave_2",
         "iconId": null,
         "skillName": "Blazing Wire Stripper",
@@ -58804,7 +58495,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_surtr_1",
         "iconId": null,
         "skillName": "Laevatain",
@@ -58899,7 +58589,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_surtr_2",
         "iconId": null,
         "skillName": "Molten Giant",
@@ -58994,7 +58683,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_surtr_3",
         "iconId": null,
         "skillName": "Twilight",
@@ -59297,7 +58985,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ethan_1",
         "iconId": null,
         "skillName": "Fancy Maneuvers",
@@ -59392,7 +59079,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ethan_2",
         "iconId": null,
         "skillName": "Suspended Cross",
@@ -59702,7 +59388,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_broca_1",
         "iconId": null,
         "skillName": "Galvanize",
@@ -59797,7 +59482,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_broca_2",
         "iconId": null,
         "skillName": "High-Voltage Current",
@@ -60121,7 +59805,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_lisa_1",
         "iconId": null,
         "skillName": "I'll Do My Best",
@@ -60216,7 +59899,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_lisa_2",
         "iconId": null,
         "skillName": "Childhood Frolic",
@@ -60311,7 +59993,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_lisa_3",
         "iconId": null,
         "skillName": "Foxfire Haze",
@@ -60635,7 +60316,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_charge_cost[3]",
         "iconId": null,
         "skillName": "冲锋号令·γ型",
@@ -60730,7 +60410,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_saga_2",
         "iconId": null,
         "skillName": "除恶",
@@ -60825,7 +60504,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_saga_3",
         "iconId": null,
         "skillName": "怒目",
@@ -61135,7 +60813,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_toddi_1",
         "iconId": null,
         "skillName": "信号矢",
@@ -61230,7 +60907,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_toddi_2",
         "iconId": null,
         "skillName": "便携破城矢",
@@ -61540,7 +61216,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_aprl_1",
         "iconId": null,
         "skillName": "Precise Shooting",
@@ -61635,7 +61310,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_aprl_2",
         "iconId": null,
         "skillName": "Flexible Camouflage",
@@ -61938,7 +61612,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_acdrop_1",
         "iconId": null,
         "skillName": "Fancy Shot",
@@ -62033,7 +61706,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_acdrop_2",
         "iconId": null,
         "skillName": "Trigger Time",
@@ -62343,7 +62015,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_swllow_1",
         "iconId": null,
         "skillName": "Flying Feathers",
@@ -62438,7 +62109,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_swllow_2",
         "iconId": null,
         "skillName": "Counterflow",
@@ -62748,7 +62418,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_bena_1",
         "iconId": null,
         "skillName": "奋力修剪",
@@ -62843,7 +62512,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bena_2",
         "iconId": null,
         "skillName": "快速修剪",
@@ -63153,7 +62821,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -63248,7 +62915,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_lionhd_2",
         "iconId": null,
         "skillName": "Deconstruct and Detonate",
@@ -63568,7 +63234,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_asbest_1",
         "iconId": null,
         "skillName": "Resilient Mode",
@@ -63663,7 +63328,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_asbest_2",
         "iconId": null,
         "skillName": "Thermal Power Mode",
@@ -63973,7 +63637,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_atk_up[3]",
         "iconId": null,
         "skillName": "ATK Up γ",
@@ -64068,7 +63731,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_sesa_2",
         "iconId": null,
         "skillName": "Delayed Concussive Parts",
@@ -64371,7 +64033,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_def_up[2]",
         "iconId": null,
         "skillName": "DEF Up β",
@@ -64466,7 +64127,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bubble_2",
         "iconId": null,
         "skillName": "\"Beaten Up\"",
@@ -64776,7 +64436,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_snsant_1",
         "iconId": null,
         "skillName": "Barbed Clawhook",
@@ -64871,7 +64530,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_snsant_2",
         "iconId": null,
         "skillName": "Telescoping Electric Net",
@@ -65174,7 +64832,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_finlpp_1",
         "iconId": null,
         "skillName": "Healing Waves",
@@ -65269,7 +64926,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_finlpp_2",
         "iconId": null,
         "skillName": "Lifespring",
@@ -65579,7 +65235,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_mint_1",
         "iconId": null,
         "skillName": "Wind Whispers",
@@ -65674,7 +65329,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_mint_2",
         "iconId": null,
         "skillName": "Swirling Vortex",
@@ -65998,7 +65652,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_rosmon_1",
         "iconId": null,
         "skillName": "Expanded Cognition",
@@ -66093,7 +65746,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_rosmon_2",
         "iconId": null,
         "skillName": "Nociceptor Inhibition",
@@ -66188,7 +65840,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_rosmon_3",
         "iconId": null,
         "skillName": "“As You Wish”",
@@ -66512,7 +66163,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_weedy_1",
         "iconId": null,
         "skillName": "Barrel Burst",
@@ -66607,7 +66257,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_weedy_2",
         "iconId": null,
         "skillName": "Hydraulics Mode",
@@ -66702,7 +66351,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_weedy_3",
         "iconId": null,
         "skillName": "Liquid Nitrogen Cannon",
@@ -67012,7 +66660,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skcom_assist_cost[3]",
         "iconId": null,
         "skillName": "Support γ",
@@ -67107,7 +66754,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_elysm_2",
         "iconId": null,
         "skillName": "Monitor",
@@ -67417,7 +67063,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_tuye_1",
         "iconId": null,
         "skillName": "水流环",
@@ -67512,7 +67157,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_tuye_2",
         "iconId": null,
         "skillName": "强心剂",
@@ -67822,7 +67466,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_absin_1",
         "iconId": null,
         "skillName": "Enforcement Mode",
@@ -67917,7 +67560,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_absin_2",
         "iconId": null,
         "skillName": "Ultimatum",
@@ -68227,7 +67869,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_tomimi_1",
         "iconId": null,
         "skillName": "Tribal Techniques",
@@ -68322,7 +67963,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_tomimi_2",
         "iconId": null,
         "skillName": "Gavial's Protection Plan",
@@ -68632,7 +68272,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_flint_1",
         "iconId": null,
         "skillName": "Relentless",
@@ -68727,7 +68366,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_flint_2",
         "iconId": null,
         "skillName": "Display of Might",
@@ -69051,7 +68689,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_zumama_1",
         "iconId": null,
         "skillName": "Tomahawk",
@@ -69146,7 +68783,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_zumama_2",
         "iconId": null,
         "skillName": "Menacing Slash",
@@ -69241,7 +68877,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_zumama_3",
         "iconId": null,
         "skillName": "Iron Will",
@@ -69565,7 +69200,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_blemsh_1",
         "iconId": null,
         "skillName": "Surging Brilliance",
@@ -69660,7 +69294,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_blemsh_2",
         "iconId": null,
         "skillName": "Deterring Radiance",
@@ -69755,7 +69388,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_blemsh_3",
         "iconId": null,
         "skillName": "Divine Avatar",
@@ -70079,7 +69711,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_billro_1",
         "iconId": null,
         "skillName": "沙暴守卫",
@@ -70174,7 +69805,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_billro_2",
         "iconId": null,
         "skillName": "沙缚镣锁",
@@ -70269,7 +69899,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_billro_3",
         "iconId": null,
         "skillName": "食噬之印",
@@ -70579,7 +70208,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_whispr_1",
         "iconId": null,
         "skillName": "Oriented Diagnosis",
@@ -70674,7 +70302,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_whispr_2",
         "iconId": null,
         "skillName": "Pain Suppression",
@@ -70977,7 +70604,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_pinecn_1",
         "iconId": null,
         "skillName": "RMA Spikes",
@@ -71072,7 +70698,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_pinecn_2",
         "iconId": null,
         "skillName": "Electrical Overcharge",
@@ -71382,7 +71007,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_robin_1",
         "iconId": null,
         "skillName": "Binding “Clip”",
@@ -71477,7 +71101,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_robin_2",
         "iconId": null,
         "skillName": "Launching “Clip”",
@@ -71780,7 +71403,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_bstalk_1",
         "iconId": null,
         "skillName": "定点指令",
@@ -71875,7 +71497,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_bstalk_2",
         "iconId": null,
         "skillName": "“大家一起上”",
@@ -72185,7 +71806,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_nothin_1",
         "iconId": null,
         "skillName": "知难而退",
@@ -72280,7 +71900,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_nothin_2",
         "iconId": null,
         "skillName": "阴晴圆缺",
@@ -72604,7 +72223,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_ash_1",
         "iconId": null,
         "skillName": "支援射击",
@@ -72699,7 +72317,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_ash_2",
         "iconId": null,
         "skillName": "突击战术",
@@ -72794,7 +72411,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_ash_3",
         "iconId": null,
         "skillName": "攻坚榴弹",
@@ -73104,7 +72720,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_blitz_1",
         "iconId": null,
         "skillName": "闪光护盾",
@@ -73199,7 +72814,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_blitz_2",
         "iconId": null,
         "skillName": "突破防线",
@@ -73509,7 +73123,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_rfrost_1",
         "iconId": null,
         "skillName": "陷阱部署",
@@ -73604,7 +73217,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_rfrost_2",
         "iconId": null,
         "skillName": "击倒猎物",
@@ -73914,7 +73526,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_tachak_1",
         "iconId": null,
         "skillName": "燃烧榴弹",
@@ -74009,7 +73620,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_tachak_2",
         "iconId": null,
         "skillName": "倾泻弹药",
@@ -74312,7 +73922,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_indigo_1",
         "iconId": null,
         "skillName": "灯塔守卫者",
@@ -74407,7 +74016,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_indigo_2",
         "iconId": null,
         "skillName": "光影迷宫",
@@ -74731,7 +74339,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_pasngr_1",
         "iconId": null,
         "skillName": "电能之触",
@@ -74826,7 +74433,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_pasngr_2",
         "iconId": null,
         "skillName": "聚焦指令",
@@ -74921,7 +74527,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_pasngr_3",
         "iconId": null,
         "skillName": "辉煌裂片",
@@ -75245,7 +74850,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_glady_1",
         "iconId": null,
         "skillName": "缺水的大洋裂断",
@@ -75340,7 +74944,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_glady_2",
         "iconId": null,
         "skillName": "缺水的掌握怒海",
@@ -75435,7 +75038,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_glady_3",
         "iconId": null,
         "skillName": "缺水的碎漩狂舞",
@@ -75745,7 +75347,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_akafyu_1",
         "iconId": null,
         "skillName": "信影流·雷刀之势",
@@ -75840,7 +75441,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_akafyu_2",
         "iconId": null,
         "skillName": "信影流·十文字胜",
@@ -76150,7 +75750,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_kirara_1",
         "iconId": null,
         "skillName": "锚击",
@@ -76245,7 +75844,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_kirara_2",
         "iconId": null,
         "skillName": "锚点捕捉",
@@ -76569,7 +76167,6 @@
     ],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_pallas_1",
         "iconId": null,
         "skillName": "胜利的连击",
@@ -76664,7 +76261,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_pallas_2",
         "iconId": null,
         "skillName": "信念的长鞭",
@@ -76759,7 +76355,6 @@
         ]
       },
       {
-        "slot": 3,
         "skillId": "skchr_pallas_3",
         "iconId": null,
         "skillName": "英勇的祝福",
@@ -76905,7 +76500,6 @@
     "elite": [],
     "skills": [
       {
-        "slot": 1,
         "skillId": "skchr_amiya2_1",
         "iconId": null,
         "skillName": "Ying Xiao - Fleeting Night",
@@ -77000,7 +76594,6 @@
         ]
       },
       {
-        "slot": 2,
         "skillId": "skchr_amiya2_2",
         "iconId": null,
         "skillName": "Ying Xiao - Shadowless",

--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -4,6 +4,7 @@
     "name": "Amiya",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -503,6 +504,7 @@
     "name": "Kal'tsit",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -1016,14 +1018,17 @@
     "name": "12F",
     "isCnOnly": false,
     "rarity": 2,
+    "class": "Caster",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_010_chen",
     "name": "Ch'en",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -1537,6 +1542,7 @@
     "name": "Blaze",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -2050,6 +2056,7 @@
     "name": "Sora",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -2454,6 +2461,7 @@
     "name": "Lava the Purgatory",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -2858,6 +2866,7 @@
     "name": "Skadi the Corrupting Heart",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -3371,6 +3380,7 @@
     "name": "Texas",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -3775,6 +3785,7 @@
     "name": "Exusiai",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -4288,6 +4299,7 @@
     "name": "Franka",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -4692,6 +4704,7 @@
     "name": "Liskarm",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -5096,6 +5109,7 @@
     "name": "Silence",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -5500,6 +5514,7 @@
     "name": "Gitano",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -5897,6 +5912,7 @@
     "name": "Deepcolor",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -6294,6 +6310,7 @@
     "name": "Siege",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -6807,6 +6824,7 @@
     "name": "W",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -7320,6 +7338,7 @@
     "name": "Zima",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -7724,6 +7743,7 @@
     "name": "Myrrh",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -8121,6 +8141,7 @@
     "name": "Shirayuki",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -8518,6 +8539,7 @@
     "name": "Hibiscus",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -8660,6 +8682,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_heal_up[1]",
+        "iconId": null,
+        "skillName": "Healing Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -8667,6 +8698,7 @@
     "name": "Lava",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -8809,6 +8841,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_magic_rage[1]",
+        "iconId": null,
+        "skillName": "Tactical Chant α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -8816,6 +8857,7 @@
     "name": "Beagle",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -8958,6 +9000,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_def_up[1]",
+        "iconId": null,
+        "skillName": "DEF Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -8965,6 +9016,7 @@
     "name": "Fang",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -9107,6 +9159,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_charge_cost[1]",
+        "iconId": null,
+        "skillName": "Charge α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -9114,6 +9175,7 @@
     "name": "Kroos",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -9256,6 +9318,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_kroos_1",
+        "iconId": null,
+        "skillName": "Double Tap - Auto",
+        "masteries": []
+      }
     ]
   },
   {
@@ -9263,6 +9334,7 @@
     "name": "Meteor",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -9660,6 +9732,7 @@
     "name": "Estelle",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -10057,6 +10130,7 @@
     "name": "Ptilopsis",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -10461,6 +10535,7 @@
     "name": "Blue Poison",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -10865,6 +10940,7 @@
     "name": "Dobermann",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -11262,6 +11338,7 @@
     "name": "Flamebringer",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -11666,6 +11743,7 @@
     "name": "May",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -12063,6 +12141,7 @@
     "name": "Ifrit",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -12576,6 +12655,7 @@
     "name": "Hoshiguma",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -13089,6 +13169,7 @@
     "name": "Beehunter",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -13486,6 +13567,7 @@
     "name": "Lappland",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -13890,6 +13972,7 @@
     "name": "Haze",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -14287,6 +14370,7 @@
     "name": "Specter",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -14691,6 +14775,7 @@
     "name": "Projekt Red",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -15095,6 +15180,7 @@
     "name": "Provence",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -15499,6 +15585,7 @@
     "name": "Shining",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -16012,6 +16099,7 @@
     "name": "Nearl",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -16416,6 +16504,7 @@
     "name": "Scavenger",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -16813,6 +16902,7 @@
     "name": "Cuora",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -17210,6 +17300,7 @@
     "name": "Myrtle",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -17607,6 +17698,7 @@
     "name": "Indra",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -18011,6 +18103,7 @@
     "name": "Firewatch",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -18415,6 +18508,7 @@
     "name": "Conviction",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -18812,6 +18906,7 @@
     "name": "Vulcan",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -19216,6 +19311,7 @@
     "name": "Nightmare",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -19620,6 +19716,7 @@
     "name": "Skyfire",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -20024,6 +20121,7 @@
     "name": "Warfarin",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -20428,6 +20526,7 @@
     "name": "SilverAsh",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -20941,6 +21040,7 @@
     "name": "Cliffheart",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -21345,6 +21445,7 @@
     "name": "Pramanix",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -21749,6 +21850,7 @@
     "name": "Nightingale",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -22262,6 +22364,7 @@
     "name": "Eyjafjalla",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -22775,6 +22878,7 @@
     "name": "Perfumer",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -23172,6 +23276,7 @@
     "name": "Earthspirit",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -23569,6 +23674,7 @@
     "name": "Mousse",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -23966,6 +24072,7 @@
     "name": "Gavial",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -24363,6 +24470,7 @@
     "name": "Hellagur",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -24876,6 +24984,7 @@
     "name": "Vermeil",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -25273,6 +25382,7 @@
     "name": "Plume",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -25415,6 +25525,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_quickattack[1]",
+        "iconId": null,
+        "skillName": "Swift Strike α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -25422,6 +25541,7 @@
     "name": "Frostleaf",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -25819,6 +25939,7 @@
     "name": "Istina",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -26223,6 +26344,7 @@
     "name": "Gummy",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -26620,6 +26742,7 @@
     "name": "Rosa",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -27133,6 +27256,7 @@
     "name": "Courier",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -27530,6 +27654,7 @@
     "name": "Matterhorn",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -27927,6 +28052,7 @@
     "name": "Croissant",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -28331,6 +28457,7 @@
     "name": "Ceobe",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -28844,6 +28971,7 @@
     "name": "Nian",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -29357,6 +29485,7 @@
     "name": "Dusk",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -29870,6 +29999,7 @@
     "name": "Saria",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -30383,6 +30513,7 @@
     "name": "Platinum",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -30787,6 +30918,7 @@
     "name": "Melantha",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -30929,6 +31061,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_atk_up[1]",
+        "iconId": null,
+        "skillName": "ATK Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -30936,6 +31077,7 @@
     "name": "Cardigan",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -31078,6 +31220,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_heal_self[1]",
+        "iconId": null,
+        "skillName": "Regeneration α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -31085,6 +31236,7 @@
     "name": "Steward",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -31227,6 +31379,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_stward_1",
+        "iconId": "skcom_powerstrike[1]",
+        "skillName": "Power Strike α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -31234,6 +31395,7 @@
     "name": "Adnachiel",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -31376,6 +31538,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_atk_up[1]",
+        "iconId": null,
+        "skillName": "ATK Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -31383,6 +31554,7 @@
     "name": "Ansel",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -31525,6 +31697,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_range_extend",
+        "iconId": null,
+        "skillName": "Healing Range Up",
+        "masteries": []
+      }
     ]
   },
   {
@@ -31532,6 +31713,7 @@
     "name": "Mostima",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -32045,6 +32227,7 @@
     "name": "Kafka",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -32449,6 +32632,7 @@
     "name": "Manticore",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -32853,6 +33037,7 @@
     "name": "Andreana",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -33257,6 +33442,7 @@
     "name": "Meteorite",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -33661,6 +33847,7 @@
     "name": "Grani",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -34065,6 +34252,7 @@
     "name": "Bagpipe",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -34578,6 +34766,7 @@
     "name": "Aak",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -35091,6 +35280,7 @@
     "name": "Hung",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -35495,6 +35685,7 @@
     "name": "Savage",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -35899,6 +36090,7 @@
     "name": "Jessica",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -36296,6 +36488,7 @@
     "name": "Rope",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -36693,6 +36886,7 @@
     "name": "Gravel",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -37090,6 +37284,7 @@
     "name": "Vanilla",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -37232,6 +37427,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_wyvern_1",
+        "iconId": null,
+        "skillName": "Command - Reinforcement",
+        "masteries": []
+      }
     ]
   },
   {
@@ -37239,6 +37443,7 @@
     "name": "FEater",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -37643,6 +37848,7 @@
     "name": "Mayer",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -38047,6 +38253,7 @@
     "name": "Waai Fu",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -38451,6 +38658,7 @@
     "name": "Magallan",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -38964,6 +39172,7 @@
     "name": "Phantom",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -39477,6 +39686,7 @@
     "name": "Bibeak",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -39881,6 +40091,7 @@
     "name": "Greyy",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -40278,6 +40489,7 @@
     "name": "Shamare",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -40682,6 +40894,7 @@
     "name": "Podenco",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -41079,6 +41292,7 @@
     "name": "Dur-nar",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -41476,6 +41690,7 @@
     "name": "Reed",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -41880,6 +42095,7 @@
     "name": "Skadi",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -42393,6 +42609,7 @@
     "name": "Mountain",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -42906,6 +43123,7 @@
     "name": "Whislash",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -43310,6 +43528,7 @@
     "name": "Arene",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -43707,6 +43926,7 @@
     "name": "Jaye",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -44104,6 +44324,7 @@
     "name": "Astesia",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -44508,6 +44729,7 @@
     "name": "Breeze",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -44912,6 +45134,7 @@
     "name": "Shaw",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -45309,6 +45532,7 @@
     "name": "Orchid",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -45451,6 +45675,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_quickattack[1]",
+        "iconId": null,
+        "skillName": "Swift Strike α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -45458,6 +45691,7 @@
     "name": "Executor",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -45862,6 +46096,7 @@
     "name": "Popukar",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -46004,6 +46239,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skcom_atk_up[1]",
+        "iconId": null,
+        "skillName": "ATK Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -46011,6 +46255,7 @@
     "name": "Catapult",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -46153,6 +46398,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_catap_1",
+        "iconId": "skcom_blowrange_up[1]",
+        "skillName": "Blast Range Up α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -46160,6 +46414,7 @@
     "name": "Midnight",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -46302,6 +46557,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_midn_1",
+        "iconId": "skcom_enchant[1]",
+        "skillName": "Enchant Weapon α",
+        "masteries": []
+      }
     ]
   },
   {
@@ -46309,6 +46573,7 @@
     "name": "Spot",
     "isCnOnly": false,
     "rarity": 3,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -46451,6 +46716,15 @@
         "goalName": "Elite 1",
         "goalCategory": 0
       }
+    ],
+    "skills": [
+      {
+        "slot": 1,
+        "skillId": "skchr_spot_1",
+        "iconId": null,
+        "skillName": "Secondary Healing Mode",
+        "masteries": []
+      }
     ]
   },
   {
@@ -46458,22 +46732,27 @@
     "name": "Lancet-2",
     "isCnOnly": false,
     "rarity": 1,
+    "class": "Medic",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_286_cast3",
     "name": "Castle-3",
     "isCnOnly": false,
     "rarity": 1,
+    "class": "Guard",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_289_gyuki",
     "name": "Matoimaru",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -46871,6 +47150,7 @@
     "name": "Vigna",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -47268,6 +47548,7 @@
     "name": "Angelina",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -47781,6 +48062,7 @@
     "name": "Thorns",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -48294,6 +48576,7 @@
     "name": "Ayerscarpe",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -48698,6 +48981,7 @@
     "name": "Sussurro",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -49095,6 +49379,7 @@
     "name": "Cutter",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -49492,6 +49777,7 @@
     "name": "Ambriel",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -49889,6 +50175,7 @@
     "name": "Heavyrain",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -50293,6 +50580,7 @@
     "name": "Leizi",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -50697,6 +50985,7 @@
     "name": "Swire",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -51101,6 +51390,7 @@
     "name": "Mudrock",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -51614,6 +51904,7 @@
     "name": "Bison",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -52018,6 +52309,7 @@
     "name": "Glaucus",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -52422,6 +52714,7 @@
     "name": "Click",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -52819,6 +53112,7 @@
     "name": "Archetto",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -53332,6 +53626,7 @@
     "name": "Sideroca",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -53736,6 +54031,7 @@
     "name": "Scene",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -54140,6 +54436,7 @@
     "name": "Utage",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -54537,6 +54834,7 @@
     "name": "Iris",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -54941,6 +55239,7 @@
     "name": "Schwarz",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -55454,6 +55753,7 @@
     "name": "Tsukinogi",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -55858,6 +56158,7 @@
     "name": "Beeswax",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -56262,6 +56563,7 @@
     "name": "Folinic",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -56666,6 +56968,7 @@
     "name": "Aosta",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -57070,6 +57373,7 @@
     "name": "Jackie",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -57467,6 +57771,7 @@
     "name": "Ceylon",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -57871,6 +58176,7 @@
     "name": "Chiave",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -58275,6 +58581,7 @@
     "name": "Surtr",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -58788,6 +59095,7 @@
     "name": "Ethan",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -59185,6 +59493,7 @@
     "name": "Broca",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -59589,6 +59898,7 @@
     "name": "Suzuran",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Supporter",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -60102,6 +60412,7 @@
     "name": "Saga",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -60615,6 +60926,7 @@
     "name": "Toddifons",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -61019,6 +61331,7 @@
     "name": "April",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -61423,6 +61736,7 @@
     "name": "Aciddrop",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -61820,6 +62134,7 @@
     "name": "GreyThroat",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -62224,6 +62539,7 @@
     "name": "Bena",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -62628,6 +62944,7 @@
     "name": "Leonhardt",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -63032,14 +63349,17 @@
     "name": "Thermal-EX",
     "isCnOnly": false,
     "rarity": 1,
+    "class": "Specialist",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_378_asbest",
     "name": "Asbestos",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -63444,6 +63764,7 @@
     "name": "Sesa",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -63848,6 +64169,7 @@
     "name": "Bubble",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -64245,6 +64567,7 @@
     "name": "Snowsant",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -64649,6 +64972,7 @@
     "name": "Purestream",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -65046,6 +65370,7 @@
     "name": "Mint",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -65450,6 +65775,7 @@
     "name": "Rosmontis",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -65963,6 +66289,7 @@
     "name": "Weedy",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -66476,6 +66803,7 @@
     "name": "Elysium",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -66880,6 +67208,7 @@
     "name": "Tuye",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -67284,6 +67613,7 @@
     "name": "Absinthe",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -67688,6 +68018,7 @@
     "name": "Tomimi",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -68092,6 +68423,7 @@
     "name": "Flint",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -68496,6 +68828,7 @@
     "name": "Eunectes",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -69009,6 +69342,7 @@
     "name": "Blemishine",
     "isCnOnly": false,
     "rarity": 6,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -69522,6 +69856,7 @@
     "name": "Carnelian",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -70035,6 +70370,7 @@
     "name": "Whisperain",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Medic",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -70439,6 +70775,7 @@
     "name": "Pinecone",
     "isCnOnly": false,
     "rarity": 4,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -70836,6 +71173,7 @@
     "name": "Robin",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -71240,6 +71578,7 @@
     "name": "Beanstalk",
     "isCnOnly": true,
     "rarity": 4,
+    "class": "Vanguard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -71637,6 +71976,7 @@
     "name": "Mr.Nothing",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -72041,6 +72381,7 @@
     "name": "Ash",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Sniper",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -72554,6 +72895,7 @@
     "name": "Blitz",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Defender",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -72958,6 +73300,7 @@
     "name": "Frost",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -73362,6 +73705,7 @@
     "name": "Tachanka",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -73766,6 +74110,7 @@
     "name": "Indigo",
     "isCnOnly": true,
     "rarity": 4,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -74163,6 +74508,7 @@
     "name": "Passenger",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Caster",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -74676,6 +75022,7 @@
     "name": "Gladiia",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -75189,6 +75536,7 @@
     "name": "Akafuyu",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -75593,6 +75941,7 @@
     "name": "Kirara",
     "isCnOnly": true,
     "rarity": 5,
+    "class": "Specialist",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -75997,6 +76346,7 @@
     "name": "Pallas",
     "isCnOnly": true,
     "rarity": 6,
+    "class": "Guard",
     "skillLevels": [
       {
         "skillLevel": 2,
@@ -76510,38 +76860,49 @@
     "name": "Noir Corne",
     "isCnOnly": false,
     "rarity": 2,
+    "class": "Defender",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_501_durin",
     "name": "Durin",
     "isCnOnly": false,
     "rarity": 2,
+    "class": "Caster",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_502_nblade",
     "name": "Yato",
     "isCnOnly": false,
     "rarity": 2,
+    "class": "Vanguard",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_503_rang",
     "name": "Rangers",
     "isCnOnly": false,
     "rarity": 2,
+    "class": "Sniper",
     "skillLevels": [],
-    "elite": []
+    "elite": [],
+    "skills": []
   },
   {
     "id": "char_1001_amiya2",
     "name": "Amiya (Guard)",
     "isCnOnly": false,
     "rarity": 5,
+    "class": "Guard",
+    "skillLevels": [],
+    "elite": [],
     "skills": [
       {
         "slot": 1,

--- a/src/pages/planner.tsx
+++ b/src/pages/planner.tsx
@@ -98,10 +98,13 @@ function Planner(): React.ReactElement {
 
   const operatorPresets: string[] = [];
   if (operator) {
-    if (operator.elite && operator.skillLevels) {
+    if (operator.elite.length > 0 && operator.skillLevels.length > 0) {
       operatorPresets.push("Elite 1, Skill Level 1 → 7");
     }
-    if (operator.skills.length === 3) {
+    if (
+      operator.skills.length === 3 &&
+      operator.skills[2].masteries.length === 3
+    ) {
       operatorPresets.push("Skill 3 Mastery 1 → 3");
     }
     operatorPresets.push("Everything");
@@ -112,11 +115,7 @@ function Planner(): React.ReactElement {
       let goals: Goal[] = [];
       if (presetName === "Elite 1, Skill Level 1 → 7") {
         goals = [operator.elite[0], ...operator.skillLevels];
-      } else if (
-        presetName === "Skill 3 Mastery 1 → 3" &&
-        operator.skills &&
-        operator.skills[2]
-      ) {
+      } else if (presetName === "Skill 3 Mastery 1 → 3") {
         goals = operator.skills[2].masteries;
       } else if (presetName === "Everything") {
         goals = [
@@ -136,15 +135,11 @@ function Planner(): React.ReactElement {
     }
     setOperatorGoals((prevOperatorGoals) => {
       const goalNamesSet = new Set(goalNames);
-      const elite = operator.elite || [];
-      const masteries = operator.skills
-        ? [...operator.skills.flatMap((skill) => skill.masteries)]
-        : [];
-      const skillLevels = operator.skillLevels || [];
+      const masteries = operator.skills.flatMap((skill) => skill.masteries);
       const goalsToAdd = [
-        ...elite,
+        ...operator.elite,
         ...masteries,
-        ...skillLevels,
+        ...operator.skillLevels,
       ].filter((goal) => goalNamesSet.has(goal.goalName));
       const deduplicated = Object.fromEntries([
         ...prevOperatorGoals.map((opGoal) => [
@@ -235,7 +230,7 @@ function Planner(): React.ReactElement {
   };
 
   const renderGoalSelectOptions = () => {
-    if (!operatorName) {
+    if (!operatorName || !operator) {
       return <MenuItem>Please select an operator first.</MenuItem>;
     }
 
@@ -251,26 +246,29 @@ function Planner(): React.ReactElement {
           ]
         : [];
 
-    const elite = operator?.elite
-      ? [
-          <ListSubheader key="elite">Elite Levels</ListSubheader>,
-          ...operator.elite.map((goal) => renderGoalMenuItem(goal)),
-        ]
-      : [];
-    const masteries = operator?.skills
-      ? [
-          <ListSubheader key="masteries">Masteries</ListSubheader>,
-          ...operator.skills.map((skill) =>
-            skill.masteries.map((goal) => renderGoalMenuItem(goal, skill))
-          ),
-        ]
-      : [];
-    const skillLevels = operator?.skillLevels
-      ? [
-          <ListSubheader key="skillLevels">Skill Levels</ListSubheader>,
-          ...operator.skillLevels.map((goal) => renderGoalMenuItem(goal)),
-        ]
-      : [];
+    const elite =
+      operator.elite.length > 0
+        ? [
+            <ListSubheader key="elite">Elite Levels</ListSubheader>,
+            ...operator.elite.map((goal) => renderGoalMenuItem(goal)),
+          ]
+        : [];
+    const masteries =
+      operator.skills.length > 0 && operator.skills[0].masteries.length > 0
+        ? [
+            <ListSubheader key="masteries">Masteries</ListSubheader>,
+            ...operator.skills.map((skill) =>
+              skill.masteries.map((goal) => renderGoalMenuItem(goal, skill))
+            ),
+          ]
+        : [];
+    const skillLevels =
+      operator.skillLevels.length > 0
+        ? [
+            <ListSubheader key="skillLevels">Skill Levels</ListSubheader>,
+            ...operator.skillLevels.map((goal) => renderGoalMenuItem(goal)),
+          ]
+        : [];
     return [...presets, ...elite, ...masteries, ...skillLevels];
   };
 

--- a/src/pages/planner.tsx
+++ b/src/pages/planner.tsx
@@ -101,7 +101,7 @@ function Planner(): React.ReactElement {
     if (operator.elite && operator.skillLevels) {
       operatorPresets.push("Elite 1, Skill Level 1 → 7");
     }
-    if (operator.skills?.length === 3) {
+    if (operator.skills.length === 3) {
       operatorPresets.push("Skill 3 Mastery 1 → 3");
     }
     operatorPresets.push("Everything");
@@ -120,9 +120,9 @@ function Planner(): React.ReactElement {
         goals = operator.skills[2].masteries;
       } else if (presetName === "Everything") {
         goals = [
-          ...(operator.elite || []),
-          ...(operator.skills?.flatMap((skill) => skill.masteries) || []),
-          ...(operator.skillLevels || []),
+          ...operator.elite,
+          ...operator.skills.flatMap((skill) => skill.masteries),
+          ...operator.skillLevels,
         ];
       }
       return goals.map((goal) => goal.goalName);
@@ -160,8 +160,7 @@ function Planner(): React.ReactElement {
             return [
               key,
               Object.assign(goalObject, {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                skill: operator.skills!.find((skill) => skill.slot === slot),
+                skill: operator.skills[slot - 1],
               }),
             ];
           }

--- a/src/pages/planner.tsx
+++ b/src/pages/planner.tsx
@@ -72,7 +72,6 @@ function Planner(): React.ReactElement {
               }
               skillId
               skillName
-              slot
             }
           }
         }

--- a/src/stories/OperatorGoalCard.stories.tsx
+++ b/src/stories/OperatorGoalCard.stories.tsx
@@ -70,7 +70,6 @@ SkadiAlterSkill3Mastery3.args = {
     ],
     skillId: "skchr_skadi2_3",
     skillName: '"潮涌，潮枯"',
-    slot: 3,
   },
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,15 +13,15 @@ export interface Ingredient {
 
 export interface Operator {
   name: string;
+  class: string;
   rarity: number;
   isCnOnly: boolean;
   elite: EliteGoal[];
   skillLevels: SkillLevelGoal[];
-  skills?: OperatorSkill[];
+  skills: OperatorSkill[];
 }
 
 export interface OperatorSkill {
-  slot: number;
   skillId: string;
   iconId: string | null;
   skillName: string;


### PR DESCRIPTION
Previously operators only had skill data if they had mastery data, i.e. if they were 4* and above. Now all operators (including 3* operators) have `skills` defined, and even for 1* and 2* operators the property is defined (just an empty array).

The `class` property is new and reflects the operator's in-game class in English translation, i.e. Defender, Vanguard, etc. (not the internal `profession` property which use different values like `"PIONEER"` for Vanguard).